### PR TITLE
Implement missing parser features and tests

### DIFF
--- a/tests/core_execution/test_variables.py
+++ b/tests/core_execution/test_variables.py
@@ -254,19 +254,6 @@ def test_allows_nullable_inputs_to_be_set_to_null_in_a_variable():
            {"fieldWithNullableStringInput": "null"}
 
 
-def test_allows_nullable_inputs_to_be_set_to_null_directly():
-    doc = '''
-    {
-        fieldWithNullableStringInput(input: null)
-    }
-    '''
-    ast = parse(doc)
-    result = execute(schema, None, ast)
-    assert not result.errors
-    assert result.data == \
-           {"fieldWithNullableStringInput": "null"}
-
-
 def test_allows_nullable_inputs_to_be_set_to_a_value_in_a_variable():
     doc = '''
     query SetsNullable($value: String) {

--- a/tests/core_language/test_parser.py
+++ b/tests/core_language/test_parser.py
@@ -1,5 +1,6 @@
 from pytest import raises
 from graphql.core.language.error import LanguageError
+from graphql.core.language.location import SourceLocation
 from graphql.core.language.source import Source
 from graphql.core.language.parser import parse
 from graphql.core.language import ast
@@ -7,6 +8,19 @@ from fixtures import KITCHEN_SINK
 
 
 def test_parse_provides_useful_errors():
+    with raises(LanguageError) as excinfo:
+        parse("""{""")
+    assert (
+               u'Syntax Error GraphQL (1:2) Expected Name, found EOF\n'
+               u'\n'
+               u'1: {\n'
+               u'    ^\n'
+               u''
+           ) == excinfo.value.message
+
+    assert excinfo.value.positions == [1]
+    assert excinfo.value.locations == [SourceLocation(line=1, column=2)]
+
     with raises(LanguageError) as excinfo:
         parse("""{ ...MissingOn }
 fragment MissingOn Type
@@ -40,6 +54,80 @@ def test_parses_constant_default_values():
     with raises(LanguageError) as excinfo:
         parse('query Foo($x: Complex = { a: { b: [ $var ] } }) { field }')
     assert 'Syntax Error GraphQL (1:37) Unexpected $' in str(excinfo.value)
+
+
+def test_does_not_accept_fragments_named_on():
+    with raises(LanguageError) as excinfo:
+        parse('fragment on on on { on }')
+
+    assert 'Syntax Error GraphQL (1:10) Unexpected Name "on"' in excinfo.value.message
+
+
+def test_does_not_accept_fragments_spread_of_on():
+    with raises(LanguageError) as excinfo:
+        parse('{ ...on }')
+
+    assert 'Syntax Error GraphQL (1:9) Expected Name, found }' in excinfo.value.message
+
+
+def test_does_not_allow_null_value():
+    with raises(LanguageError) as excinfo:
+        parse('{ fieldWithNullableStringInput(input: null) }')
+
+    assert 'Syntax Error GraphQL (1:39) Unexpected Name "null"' in excinfo.value.message
+
+
+def test_parses_multi_byte_characters():
+    result = parse(u'''
+        # This comment has a \u0A0A multi-byte character.
+        { field(arg: "Has a \u0A0A multi-byte character.") }
+    ''', no_location=True, no_source=True)
+    assert result == ast.Document(
+        definitions=[
+            ast.OperationDefinition(
+                operation='query', name=None, variable_definitions=None, directives=[],
+                selection_set=ast.SelectionSet(
+                    selections=[
+                        ast.Field(
+                            alias=None, name=ast.Name(value=u'field'),
+                            arguments=[
+                                ast.Argument(
+                                    name=ast.Name(value=u'arg'),
+                                    value=ast.StringValue(value=u'Has a \u0a0a multi-byte character.'))],
+                            directives=[], selection_set=None)
+                    ]
+                )
+            )
+        ]
+    )
+
+
+def tesst_allows_non_keywords_anywhere_a_name_is_allowed():
+    non_keywords = [
+      'on',
+      'fragment',
+      'query',
+      'mutation',
+      'true',
+      'false'
+    ]
+
+    query_template = '''
+    query {keyword} {
+        ... {fragment_name}
+        ... on {keyword} { field }
+    }
+    fragment {fragment_name} on Type {
+        {keyword}({keyword}: ${keyword}) @{keyword}({keyword}: {keyword})
+    }
+    '''
+
+    for keyword in non_keywords:
+        fragment_name = keyword
+        if keyword == 'on':
+            fragment_name = 'a'
+
+        parse(query_template.format(fragment_name=fragment_name, keyword=keyword))
 
 
 def test_parses_kitchen_sink():
@@ -95,12 +183,12 @@ def test_parse_creates_ast():
                                    arguments=[],
                                    directives=[],
                                    selection_set=None),
-                                ast.Field(
-                                    loc={'start': 30, 'end': 34, 'source': source},
-                                    alias=None,
-                                    name=ast.Name(
-                                        loc={'start': 30, 'end': 34, 'source': source},
-                                        value='name'),
-                                    arguments=[],
-                                    directives=[],
-                                    selection_set=None)]))]))])
+                                   ast.Field(
+                                       loc={'start': 30, 'end': 34, 'source': source},
+                                       alias=None,
+                                       name=ast.Name(
+                                           loc={'start': 30, 'end': 34, 'source': source},
+                                           value='name'),
+                                       arguments=[],
+                                       directives=[],
+                                       selection_set=None)]))]))])


### PR DESCRIPTION
- Null value restriction to Enum value parser: https://github.com/graphql/graphql-js/commit/704f975f3dd08ef09c30e861b22c10ab2a8bb687
- Fragment name lookahead in parser https://github.com/graphql/graphql-js/commit/8ae5bd7e4d733c99dbbbece347eb15c4bcded951
- Tricky parser test https://github.com/graphql/graphql-js/commit/da5c4b0814887382067dcaeaddd6fed8a76a3614
