### PR TITLE
Schema parser & printer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - pypy
 cache: pip
 install:
-- pip install --cache-dir $HOME/.cache/pip pytest-cov coveralls flake8 import-order gevent==1.1b5
+- pip install --cache-dir $HOME/.cache/pip pytest-cov coveralls flake8 import-order gevent==1.1b5 six>=1.10.0
 - pip install --cache-dir $HOME/.cache/pip pytest>=2.7.3 --upgrade
 - pip install -e .
 script:

--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -272,7 +272,7 @@ class Executor(object):
 
         if not runtime_type.is_type_of(result, info):
             raise GraphQLError(
-                u'Expected value of type "{}" but got {}.'.format(return_type, result),
+                u'Expected value of type "{}" but got {}.'.format(return_type, type(result).__name__),
                 field_asts
             )
 

--- a/graphql/core/language/ast.py
+++ b/graphql/core/language/ast.py
@@ -32,6 +32,12 @@ class Document(Node):
                 'definitions={self.definitions!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.definitions,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -70,6 +76,16 @@ class OperationDefinition(Definition):
                 ', selection_set={self.selection_set!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.operation,
+            self.selection_set,
+            self.name,
+            self.variable_definitions,
+            self.directives,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -102,6 +118,14 @@ class VariableDefinition(Node):
                 ', default_value={self.default_value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.variable,
+            self.type,
+            self.default_value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -127,6 +151,12 @@ class SelectionSet(Node):
         return ('SelectionSet('
                 'selections={self.selections!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.selections,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -170,6 +200,16 @@ class Field(Selection):
                 ', selection_set={self.selection_set!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.alias,
+            self.arguments,
+            self.directives,
+            self.selection_set,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -199,6 +239,13 @@ class Argument(Node):
                 ', value={self.value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -227,6 +274,13 @@ class FragmentSpread(Selection):
                 'name={self.name!r}'
                 ', directives={self.directives!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.directives,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -259,6 +313,14 @@ class InlineFragment(Selection):
                 ', directives={self.directives!r}'
                 ', selection_set={self.selection_set!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.type_condition,
+            self.selection_set,
+            self.directives,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -295,6 +357,15 @@ class FragmentDefinition(Definition):
                 ', selection_set={self.selection_set!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.type_condition,
+            self.selection_set,
+            self.directives,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -325,6 +396,12 @@ class Variable(Value):
                 'name={self.name!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -350,6 +427,12 @@ class IntValue(Value):
         return ('IntValue('
                 'value={self.value!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -377,6 +460,12 @@ class FloatValue(Value):
                 'value={self.value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -402,6 +491,12 @@ class StringValue(Value):
         return ('StringValue('
                 'value={self.value!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -429,6 +524,12 @@ class BooleanValue(Value):
                 'value={self.value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -454,6 +555,12 @@ class EnumValue(Value):
         return ('EnumValue('
                 'value={self.value!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -481,6 +588,12 @@ class ListValue(Value):
                 'values={self.values!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.values,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -506,6 +619,12 @@ class ObjectValue(Value):
         return ('ObjectValue('
                 'fields={self.fields!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.fields,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -536,6 +655,13 @@ class ObjectField(Node):
                 ', value={self.value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -564,6 +690,13 @@ class Directive(Node):
                 'name={self.name!r}'
                 ', arguments={self.arguments!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.arguments,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -595,6 +728,12 @@ class NamedType(Type):
                 'name={self.name!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -620,6 +759,12 @@ class ListType(Type):
         return ('ListType('
                 'type={self.type!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.type,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -647,6 +792,12 @@ class NonNullType(Type):
                 'type={self.type!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.type,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -672,6 +823,12 @@ class Name(Node):
         return ('Name('
                 'value={self.value!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.value,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -709,6 +866,14 @@ class ObjectTypeDefinition(TypeDefinition):
                 ', fields={self.fields!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.fields,
+            self.interfaces,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -740,6 +905,14 @@ class FieldDefinition(Node):
                 ', arguments={self.arguments!r}'
                 ', type={self.type!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.arguments,
+            self.type,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -773,6 +946,14 @@ class InputValueDefinition(Node):
                 ', default_value={self.default_value!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.type,
+            self.default_value,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -801,6 +982,13 @@ class InterfaceTypeDefinition(TypeDefinition):
                 'name={self.name!r}'
                 ', fields={self.fields!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.fields,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -831,6 +1019,13 @@ class UnionTypeDefinition(TypeDefinition):
                 ', types={self.types!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.types,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -856,6 +1051,12 @@ class ScalarTypeDefinition(TypeDefinition):
         return ('ScalarTypeDefinition('
                 'name={self.name!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -886,6 +1087,13 @@ class EnumTypeDefinition(TypeDefinition):
                 ', values={self.values!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.values,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -911,6 +1119,12 @@ class EnumValueDefinition(Node):
         return ('EnumValueDefinition('
                 'name={self.name!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)
@@ -941,6 +1155,13 @@ class InputObjectTypeDefinition(TypeDefinition):
                 ', fields={self.fields!r}'
                 ')').format(self=self)
 
+    def __copy__(self):
+        return type(self)(
+            self.name,
+            self.fields,
+            self.loc
+        )
+
     def __hash__(self):
         return id(self)
 
@@ -966,6 +1187,12 @@ class TypeExtensionDefinition(TypeDefinition):
         return ('TypeExtensionDefinition('
                 'definition={self.definition!r}'
                 ')').format(self=self)
+
+    def __copy__(self):
+        return type(self)(
+            self.definition,
+            self.loc
+        )
 
     def __hash__(self):
         return id(self)

--- a/graphql/core/language/ast.py
+++ b/graphql/core/language/ast.py
@@ -675,3 +675,297 @@ class Name(Node):
 
     def __hash__(self):
         return id(self)
+
+
+class TypeDefinition(Node):
+    pass
+
+
+class ObjectTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name', 'interfaces', 'fields',)
+    _fields = ('name', 'interfaces', 'fields',)
+
+    def __init__(self, name, fields, interfaces=None, loc=None):
+        self.loc = loc
+        self.name = name
+        self.interfaces = interfaces
+        self.fields = fields
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, ObjectTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.interfaces == other.interfaces and
+                self.fields == other.fields
+            )
+        )
+
+    def __repr__(self):
+        return ('ObjectTypeDefinition('
+                'name={self.name!r}'
+                ', interfaces={self.interfaces!r}'
+                ', fields={self.fields!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class FieldDefinition(Node):
+    __slots__ = ('loc', 'name', 'arguments', 'type',)
+    _fields = ('name', 'arguments', 'type',)
+
+    def __init__(self, name, arguments, type, loc=None):
+        self.loc = loc
+        self.name = name
+        self.arguments = arguments
+        self.type = type
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, FieldDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.arguments == other.arguments and
+                self.type == other.type
+            )
+        )
+
+    def __repr__(self):
+        return ('FieldDefinition('
+                'name={self.name!r}'
+                ', arguments={self.arguments!r}'
+                ', type={self.type!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class InputValueDefinition(Node):
+    __slots__ = ('loc', 'name', 'type', 'default_value',)
+    _fields = ('name', 'type', 'default_value',)
+
+    def __init__(self, name, type, default_value=None, loc=None):
+        self.loc = loc
+        self.name = name
+        self.type = type
+        self.default_value = default_value
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, InputValueDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.type == other.type and
+                self.default_value == other.default_value
+            )
+        )
+
+    def __repr__(self):
+        return ('InputValueDefinition('
+                'name={self.name!r}'
+                ', type={self.type!r}'
+                ', default_value={self.default_value!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class InterfaceTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name', 'fields',)
+    _fields = ('name', 'fields',)
+
+    def __init__(self, name, fields, loc=None):
+        self.loc = loc
+        self.name = name
+        self.fields = fields
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, InterfaceTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.fields == other.fields
+            )
+        )
+
+    def __repr__(self):
+        return ('InterfaceTypeDefinition('
+                'name={self.name!r}'
+                ', fields={self.fields!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class UnionTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name', 'types',)
+    _fields = ('name', 'types',)
+
+    def __init__(self, name, types, loc=None):
+        self.loc = loc
+        self.name = name
+        self.types = types
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, UnionTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.types == other.types
+            )
+        )
+
+    def __repr__(self):
+        return ('UnionTypeDefinition('
+                'name={self.name!r}'
+                ', types={self.types!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class ScalarTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name',)
+    _fields = ('name',)
+
+    def __init__(self, name, loc=None):
+        self.loc = loc
+        self.name = name
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, ScalarTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name
+            )
+        )
+
+    def __repr__(self):
+        return ('ScalarTypeDefinition('
+                'name={self.name!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class EnumTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name', 'values',)
+    _fields = ('name', 'values',)
+
+    def __init__(self, name, values, loc=None):
+        self.loc = loc
+        self.name = name
+        self.values = values
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, EnumTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.values == other.values
+            )
+        )
+
+    def __repr__(self):
+        return ('EnumTypeDefinition('
+                'name={self.name!r}'
+                ', values={self.values!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class EnumValueDefinition(Node):
+    __slots__ = ('loc', 'name',)
+    _fields = ('name',)
+
+    def __init__(self, name, loc=None):
+        self.loc = loc
+        self.name = name
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, EnumValueDefinition) and
+                self.loc == other.loc and
+                self.name == other.name
+            )
+        )
+
+    def __repr__(self):
+        return ('EnumValueDefinition('
+                'name={self.name!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class InputObjectTypeDefinition(TypeDefinition):
+    __slots__ = ('loc', 'name', 'fields',)
+    _fields = ('name', 'fields',)
+
+    def __init__(self, name, fields, loc=None):
+        self.loc = loc
+        self.name = name
+        self.fields = fields
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, InputObjectTypeDefinition) and
+                self.loc == other.loc and
+                self.name == other.name and
+                self.fields == other.fields
+            )
+        )
+
+    def __repr__(self):
+        return ('InputObjectTypeDefinition('
+                'name={self.name!r}'
+                ', fields={self.fields!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)
+
+
+class TypeExtensionDefinition(TypeDefinition):
+    __slots__ = ('loc', 'definition',)
+    _fields = ('definition',)
+
+    def __init__(self, definition, loc=None):
+        self.loc = loc
+        self.definition = definition
+
+    def __eq__(self, other):
+        return (
+            self is other or (
+                isinstance(other, TypeExtensionDefinition) and
+                self.loc == other.loc and
+                self.definition == other.definition
+            )
+        )
+
+    def __repr__(self):
+        return ('TypeExtensionDefinition('
+                'definition={self.definition!r}'
+                ')').format(self=self)
+
+    def __hash__(self):
+        return id(self)

--- a/graphql/core/language/parser.py
+++ b/graphql/core/language/parser.py
@@ -639,7 +639,7 @@ def parse_scalar_type_definition(parser):
 
 
 def parse_enum_type_definition(parser):
-    start = parser.tokens.start
+    start = parser.token.start
     expect_keyword(parser, 'enum')
 
     return ast.EnumTypeDefinition(

--- a/graphql/core/language/printer.py
+++ b/graphql/core/language/printer.py
@@ -23,9 +23,11 @@ class PrintingVisitor(Visitor):
         selection_set = node.selection_set
         if not name:
             return selection_set
+
         op = node.operation
         defs = wrap('(', join(node.variable_definitions, ', '), ')')
         directives = join(node.directives, ' ')
+
         return join([op, join([name, defs]), directives, selection_set], ' ')
 
     def leave_VariableDefinition(self, node, *args):
@@ -103,6 +105,42 @@ class PrintingVisitor(Visitor):
 
     def leave_NonNullType(self, node, *args):
         return node.type + '!'
+
+    # Type Definitions:
+
+    def leave_ObjectTypeDefinition(self, node, *args):
+        return (
+            'type ' + node.name + ' ' +
+            wrap('implements ', join(node.interfaces, ', '), ' ') +
+            block(node.fields)
+        )
+
+    def leave_FieldDefinition(self, node, *args):
+        return node.name + wrap('(', join(node.arguments, ', '), ')') + ': ' + node.type
+
+    def leave_InputValueDefinition(self, node, *args):
+        return node.name + ': ' + node.type + wrap(' = ', node.default_value)
+
+    def leave_InterfaceTypeDefinition(self, node, *args):
+        return 'interface ' + node.name + ' ' + block(node.fields)
+
+    def leave_UnionTypeDefinition(self, node, *args):
+        return 'union ' + node.name + ' = ' + join(node.types, ' | ')
+
+    def leave_ScalarTypeDefinition(self, node, *args):
+        return 'scalar ' + node.name
+
+    def leave_EnumTypeDefinition(self, node, *args):
+        return 'enum ' + node.name + ' ' + block(node.values)
+
+    def leave_EnumValueDefinition(self, node, *args):
+        return node.name
+
+    def leave_InputObjectTypeDefinition(self, node, *args):
+        return 'input ' + node.name + ' ' + block(node.fields)
+
+    def leave_TypeExtensionDefinition(self, node, *args):
+        return 'extend ' + node.definition
 
 
 def join(maybe_list, separator=''):

--- a/graphql/core/language/visitor.py
+++ b/graphql/core/language/visitor.py
@@ -1,15 +1,15 @@
-from collections import namedtuple
-from copy import copy, deepcopy
+from copy import copy
+import six
 from . import ast
 
 QUERY_DOCUMENT_KEYS = {
     ast.Name: (),
 
-    ast.Document: ('definitions', ),
+    ast.Document: ('definitions',),
     ast.OperationDefinition: ('name', 'variable_definitions', 'directives', 'selection_set'),
     ast.VariableDefinition: ('variable', 'type', 'default_value'),
-    ast.Variable: ('name', ),
-    ast.SelectionSet: ('selections', ),
+    ast.Variable: ('name',),
+    ast.SelectionSet: ('selections',),
     ast.Field: ('alias', 'name', 'arguments', 'directives', 'selection_set'),
     ast.Argument: ('name', 'value'),
 
@@ -22,21 +22,43 @@ QUERY_DOCUMENT_KEYS = {
     ast.StringValue: (),
     ast.BooleanValue: (),
     ast.EnumValue: (),
-    ast.ListValue: ('values', ),
-    ast.ObjectValue: ('fields', ),
+    ast.ListValue: ('values',),
+    ast.ObjectValue: ('fields',),
     ast.ObjectField: ('name', 'value'),
 
     ast.Directive: ('name', 'arguments'),
 
-    ast.NamedType: ('name', ),
-    ast.ListType: ('type', ),
-    ast.NonNullType: ('type', ),
+    ast.NamedType: ('name',),
+    ast.ListType: ('type',),
+    ast.NonNullType: ('type',),
+
+    ast.ObjectTypeDefinition: ('name', 'interfaces', 'fields'),
+    ast.FieldDefinition: ('name', 'arguments', 'type'),
+    ast.InputValueDefinition: ('name', 'type', 'defaultValue'),
+    ast.InterfaceTypeDefinition: ('name', 'fields'),
+    ast.UnionTypeDefinition: ('name', 'types'),
+    ast.ScalarTypeDefinition: ('name',),
+    ast.EnumTypeDefinition: ('name', 'values'),
+    ast.EnumValueDefinition: ('name',),
+    ast.InputObjectTypeDefinition: ('name', 'fields'),
+    ast.TypeExtensionDefinition: ('definition',),
 }
+
+AST_KIND_TO_TYPE = {c.__name__: c for c in QUERY_DOCUMENT_KEYS.keys()}
 
 BREAK = object()
 REMOVE = object()
 
-Stack = namedtuple('Stack', 'in_array index keys edits prev')
+
+class Stack(object):
+    __slots__ = 'in_array', 'index', 'keys', 'edits', 'prev'
+
+    def __init__(self, in_array, index, keys, edits, prev):
+        self.in_array = in_array
+        self.index = index
+        self.keys = keys
+        self.edits = edits
+        self.prev = prev
 
 
 def visit(root, visitor, key_map=None):
@@ -51,90 +73,111 @@ def visit(root, visitor, key_map=None):
     path = []
     ancestors = []
     new_root = root
+    leave = visitor.leave
+    enter = visitor.enter
+    path_pop = path.pop
+    ancestors_pop = ancestors.pop
 
     while True:
         index += 1
         is_leaving = index == len(keys)
-        key = None
-        node = None
-        is_edited = is_leaving and len(edits) != 0
+        is_edited = is_leaving and edits
         if is_leaving:
-            key = path.pop() if len(ancestors) != 0 else None
+            key = path_pop() if ancestors else None
             node = parent
-            parent = ancestors.pop() if len(ancestors) != 0 else None
+            parent = ancestors_pop() if ancestors else None
+
             if is_edited:
                 if in_array:
                     node = list(node)
+
                 else:
                     node = copy(node)
+
                 edit_offset = 0
                 for edit_key, edit_value in edits:
                     if in_array:
                         edit_key -= edit_offset
+
                     if in_array and edit_value is REMOVE:
                         node.pop(edit_key)
                         edit_offset += 1
+
                     else:
                         if isinstance(node, list):
                             node[edit_key] = edit_value
+
                         else:
-                            node = deepcopy(node)
                             setattr(node, edit_key, edit_value)
+
             index = stack.index
             keys = stack.keys
             edits = stack.edits
             in_array = stack.in_array
             stack = stack.prev
+
         else:
             if parent:
                 key = index if in_array else keys[index]
                 if isinstance(parent, list):
                     node = parent[key]
+
                 else:
                     node = getattr(parent, key, None)
+
             else:
                 key = None
                 node = new_root
+
             if node is None:
                 continue
+
             if parent:
                 path.append(key)
 
         result = None
+
         if not isinstance(node, list):
             assert isinstance(node, ast.Node), 'Invalid AST Node: ' + repr(node)
+
             if is_leaving:
-                result = visitor.leave(node, key, parent, path, ancestors)
+                result = leave(node, key, parent, path, ancestors)
+
             else:
-                result = visitor.enter(node, key, parent, path, ancestors)
+                result = enter(node, key, parent, path, ancestors)
+
             if result is BREAK:
                 break
 
             if result is False:
                 if not is_leaving:
-                    path.pop()
+                    path_pop()
                     continue
+
             elif result is not None:
                 edits.append((key, result))
                 if not is_leaving:
                     if result is not REMOVE:
                         # TODO: check result is valid node
                         node = result
+
                     else:
-                        path.pop()
+                        path_pop()
                         continue
 
         if result is None and is_edited:
             edits.append((key, node))
 
         if not is_leaving:
-            stack = Stack(in_array, index, keys, edits, prev=stack)
+            stack = Stack(in_array, index, keys, edits, stack)
             in_array = isinstance(node, list)
-            keys = node if in_array else visitor_keys.get(type(node), [])
+            keys = node if in_array else visitor_keys.get(type(node), None) or []
             index = -1
             edits = []
+
             if parent:
                 ancestors.append(parent)
+
             parent = node
 
         if not stack:
@@ -146,16 +189,41 @@ def visit(root, visitor, key_map=None):
     return new_root
 
 
+class VisitorMeta(type):
+    def __new__(cls, name, bases, attrs):
+        enter_handlers = {}
+        leave_handlers = {}
+
+        for base in bases:
+            if hasattr(base, '_enter_handlers'):
+                enter_handlers.update(base._enter_handlers)
+            if hasattr(base, '_leave_handlers'):
+                leave_handlers.update(base._leave_handlers)
+
+        for attr, val in attrs.items():
+            if attr.startswith('enter_'):
+                ast_kind = attr[6:]
+                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
+                enter_handlers[ast_type] = val
+
+            elif attr.startswith('leave_'):
+                ast_kind = attr[6:]
+                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
+                leave_handlers[ast_type] = val
+
+        attrs['_get_enter_handler'] = enter_handlers.get
+        attrs['_get_leave_handler'] = leave_handlers.get
+        return super(VisitorMeta, cls).__new__(cls, name, bases, attrs)
+
+
+@six.add_metaclass(VisitorMeta)
 class Visitor(object):
     def enter(self, node, key, parent, path, ancestors):
-        return self._call_kind_specific_visitor('enter_', node, key, parent, path, ancestors)
+        method = self._get_enter_handler(type(node))
+        if method:
+            return method(self, node, key, parent, path, ancestors)
 
     def leave(self, node, key, parent, path, ancestors):
-        return self._call_kind_specific_visitor('leave_', node, key, parent, path, ancestors)
-
-    def _call_kind_specific_visitor(self, prefix, node, key, parent, path, ancestors):
-        node_kind = type(node).__name__
-        method_name = prefix + node_kind
-        method = getattr(self, method_name, None)
+        method = self._get_leave_handler(type(node))
         if method:
-            return method(node, key, parent, path, ancestors)
+            return method(self, node, key, parent, path, ancestors)

--- a/graphql/core/language/visitor.py
+++ b/graphql/core/language/visitor.py
@@ -2,7 +2,7 @@ from copy import copy
 
 import six
 from . import ast
-from .visitor_meta import VisitorMeta, QUERY_DOCUMENT_KEYS
+from .visitor_meta import QUERY_DOCUMENT_KEYS, VisitorMeta
 
 
 BREAK = object()

--- a/graphql/core/language/visitor.py
+++ b/graphql/core/language/visitor.py
@@ -1,50 +1,9 @@
 from copy import copy
+
 import six
 from . import ast
+from .visitor_meta import VisitorMeta, QUERY_DOCUMENT_KEYS
 
-QUERY_DOCUMENT_KEYS = {
-    ast.Name: (),
-
-    ast.Document: ('definitions',),
-    ast.OperationDefinition: ('name', 'variable_definitions', 'directives', 'selection_set'),
-    ast.VariableDefinition: ('variable', 'type', 'default_value'),
-    ast.Variable: ('name',),
-    ast.SelectionSet: ('selections',),
-    ast.Field: ('alias', 'name', 'arguments', 'directives', 'selection_set'),
-    ast.Argument: ('name', 'value'),
-
-    ast.FragmentSpread: ('name', 'directives'),
-    ast.InlineFragment: ('type_condition', 'directives', 'selection_set'),
-    ast.FragmentDefinition: ('name', 'type_condition', 'directives', 'selection_set'),
-
-    ast.IntValue: (),
-    ast.FloatValue: (),
-    ast.StringValue: (),
-    ast.BooleanValue: (),
-    ast.EnumValue: (),
-    ast.ListValue: ('values',),
-    ast.ObjectValue: ('fields',),
-    ast.ObjectField: ('name', 'value'),
-
-    ast.Directive: ('name', 'arguments'),
-
-    ast.NamedType: ('name',),
-    ast.ListType: ('type',),
-    ast.NonNullType: ('type',),
-
-    ast.ObjectTypeDefinition: ('name', 'interfaces', 'fields'),
-    ast.FieldDefinition: ('name', 'arguments', 'type'),
-    ast.InputValueDefinition: ('name', 'type', 'defaultValue'),
-    ast.InterfaceTypeDefinition: ('name', 'fields'),
-    ast.UnionTypeDefinition: ('name', 'types'),
-    ast.ScalarTypeDefinition: ('name',),
-    ast.EnumTypeDefinition: ('name', 'values'),
-    ast.EnumValueDefinition: ('name',),
-    ast.InputObjectTypeDefinition: ('name', 'fields'),
-    ast.TypeExtensionDefinition: ('definition',),
-}
-
-AST_KIND_TO_TYPE = {c.__name__: c for c in QUERY_DOCUMENT_KEYS.keys()}
 
 BREAK = object()
 REMOVE = object()
@@ -187,33 +146,6 @@ def visit(root, visitor, key_map=None):
         new_root = edits[0][1]
 
     return new_root
-
-
-class VisitorMeta(type):
-    def __new__(cls, name, bases, attrs):
-        enter_handlers = {}
-        leave_handlers = {}
-
-        for base in bases:
-            if hasattr(base, '_enter_handlers'):
-                enter_handlers.update(base._enter_handlers)
-            if hasattr(base, '_leave_handlers'):
-                leave_handlers.update(base._leave_handlers)
-
-        for attr, val in attrs.items():
-            if attr.startswith('enter_'):
-                ast_kind = attr[6:]
-                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
-                enter_handlers[ast_type] = val
-
-            elif attr.startswith('leave_'):
-                ast_kind = attr[6:]
-                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
-                leave_handlers[ast_type] = val
-
-        attrs['_get_enter_handler'] = enter_handlers.get
-        attrs['_get_leave_handler'] = leave_handlers.get
-        return super(VisitorMeta, cls).__new__(cls, name, bases, attrs)
 
 
 @six.add_metaclass(VisitorMeta)

--- a/graphql/core/language/visitor_meta.py
+++ b/graphql/core/language/visitor_meta.py
@@ -32,7 +32,7 @@ QUERY_DOCUMENT_KEYS = {
 
     ast.ObjectTypeDefinition: ('name', 'interfaces', 'fields'),
     ast.FieldDefinition: ('name', 'arguments', 'type'),
-    ast.InputValueDefinition: ('name', 'type', 'defaultValue'),
+    ast.InputValueDefinition: ('name', 'type', 'default_value'),
     ast.InterfaceTypeDefinition: ('name', 'fields'),
     ast.UnionTypeDefinition: ('name', 'types'),
     ast.ScalarTypeDefinition: ('name',),

--- a/graphql/core/language/visitor_meta.py
+++ b/graphql/core/language/visitor_meta.py
@@ -1,0 +1,72 @@
+from . import ast
+
+QUERY_DOCUMENT_KEYS = {
+    ast.Name: (),
+
+    ast.Document: ('definitions',),
+    ast.OperationDefinition: ('name', 'variable_definitions', 'directives', 'selection_set'),
+    ast.VariableDefinition: ('variable', 'type', 'default_value'),
+    ast.Variable: ('name',),
+    ast.SelectionSet: ('selections',),
+    ast.Field: ('alias', 'name', 'arguments', 'directives', 'selection_set'),
+    ast.Argument: ('name', 'value'),
+
+    ast.FragmentSpread: ('name', 'directives'),
+    ast.InlineFragment: ('type_condition', 'directives', 'selection_set'),
+    ast.FragmentDefinition: ('name', 'type_condition', 'directives', 'selection_set'),
+
+    ast.IntValue: (),
+    ast.FloatValue: (),
+    ast.StringValue: (),
+    ast.BooleanValue: (),
+    ast.EnumValue: (),
+    ast.ListValue: ('values',),
+    ast.ObjectValue: ('fields',),
+    ast.ObjectField: ('name', 'value'),
+
+    ast.Directive: ('name', 'arguments'),
+
+    ast.NamedType: ('name',),
+    ast.ListType: ('type',),
+    ast.NonNullType: ('type',),
+
+    ast.ObjectTypeDefinition: ('name', 'interfaces', 'fields'),
+    ast.FieldDefinition: ('name', 'arguments', 'type'),
+    ast.InputValueDefinition: ('name', 'type', 'defaultValue'),
+    ast.InterfaceTypeDefinition: ('name', 'fields'),
+    ast.UnionTypeDefinition: ('name', 'types'),
+    ast.ScalarTypeDefinition: ('name',),
+    ast.EnumTypeDefinition: ('name', 'values'),
+    ast.EnumValueDefinition: ('name',),
+    ast.InputObjectTypeDefinition: ('name', 'fields'),
+    ast.TypeExtensionDefinition: ('definition',),
+}
+
+AST_KIND_TO_TYPE = {c.__name__: c for c in QUERY_DOCUMENT_KEYS.keys()}
+
+
+class VisitorMeta(type):
+    def __new__(cls, name, bases, attrs):
+        enter_handlers = {}
+        leave_handlers = {}
+
+        for base in bases:
+            if hasattr(base, '_enter_handlers'):
+                enter_handlers.update(base._enter_handlers)
+            if hasattr(base, '_leave_handlers'):
+                leave_handlers.update(base._leave_handlers)
+
+        for attr, val in attrs.items():
+            if attr.startswith('enter_'):
+                ast_kind = attr[6:]
+                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
+                enter_handlers[ast_type] = val
+
+            elif attr.startswith('leave_'):
+                ast_kind = attr[6:]
+                ast_type = AST_KIND_TO_TYPE.get(ast_kind)
+                leave_handlers[ast_type] = val
+
+        attrs['_get_enter_handler'] = enter_handlers.get
+        attrs['_get_leave_handler'] = leave_handlers.get
+        return super(VisitorMeta, cls).__new__(cls, name, bases, attrs)

--- a/graphql/core/utils/ast_to_code.py
+++ b/graphql/core/utils/ast_to_code.py
@@ -1,0 +1,47 @@
+from ..language.parser import Loc
+from ..language.ast import Node
+
+
+def ast_to_code(ast, indent=0):
+    """
+    Converts an ast into a python code representation of the AST.
+    """
+    code = []
+    append = lambda line: code.append(('    ' * indent) + line)
+
+    if isinstance(ast, Node):
+        append('ast.{}('.format(ast.__class__.__name__))
+        indent += 1
+        for i, k in enumerate(ast._fields, 1):
+            v = getattr(ast, k)
+            append('{}={},'.format(
+                k,
+                ast_to_code(v, indent),
+            ))
+        if ast.loc:
+            append('loc={}'.format(ast_to_code(ast.loc, indent)))
+
+        indent -= 1
+        append(')')
+
+    elif isinstance(ast, Loc):
+        append('loc({}, {})'.format(ast.start, ast.end))
+
+    elif isinstance(ast, list):
+        if ast:
+            append('[')
+            indent += 1
+
+            for i, it in enumerate(ast, 1):
+                is_last = i == len(ast)
+                append(ast_to_code(it, indent) + (',' if not is_last else ''))
+
+            indent -= 1
+            append(']')
+        else:
+            append('[]')
+
+    else:
+        append(repr(ast))
+
+    return '\n'.join(code).strip()

--- a/graphql/core/utils/ast_to_code.py
+++ b/graphql/core/utils/ast_to_code.py
@@ -1,5 +1,5 @@
-from ..language.parser import Loc
 from ..language.ast import Node
+from ..language.parser import Loc
 
 
 def ast_to_code(ast, indent=0):

--- a/graphql/core/utils/type_info.py
+++ b/graphql/core/utils/type_info.py
@@ -1,6 +1,6 @@
 import six
 
-from ..language import ast, visitor_meta
+from ..language import visitor_meta
 from ..type.definition import (
     GraphQLInputObjectType,
     GraphQLList,

--- a/scripts/ast.ast
+++ b/scripts/ast.ast
@@ -1,0 +1,176 @@
+# Mini-language for AST definition.
+# All AST nodes extend AstNode.
+# All AST nodes are visitible.
+# All AST fields have a getter and a setter and are a constructor argument.
+# We have concrete types (code T) and unions (code U).
+# S for singular field, P for plural, ? for nullable.
+# O for option in a union.
+# Scalar type ontology: string, boolean
+
+# Location tracking for Identifier is probably useful for error messages.
+U Definition
+O OperationDefinition
+O FragmentDefinition
+
+T Document
+P Definition definitions
+
+T OperationDefinition
+S OperationKind operation
+S? Name name
+P? VariableDefinition variableDefinitions
+P? Directive directives
+S SelectionSet selectionSet
+
+T VariableDefinition
+S Variable variable
+S Type type
+S? Value defaultValue
+
+T SelectionSet
+P Selection selections
+
+U Selection
+O Field
+O FragmentSpread
+O InlineFragment
+
+T Field
+S? Name alias
+S Name name
+P? Argument arguments
+P? Directive directives
+S? SelectionSet selectionSet
+
+T Argument
+S Name name
+S Value value
+
+T FragmentSpread
+S Name name
+P? Directive directives
+
+T InlineFragment
+S NamedType typeCondition
+P? Directive directives
+S SelectionSet selectionSet
+
+T FragmentDefinition
+S Name name
+S NamedType typeCondition
+P? Directive directives
+S SelectionSet selectionSet
+
+U Value
+O Variable
+O IntValue
+O FloatValue
+O StringValue
+O BooleanValue
+O EnumValue
+O ArrayValue
+O ObjectValue
+
+T Variable
+S Name name
+
+T IntValue
+S string value
+
+T FloatValue
+S string value
+
+T StringValue
+S string value
+
+T BooleanValue
+S boolean value
+
+T EnumValue
+S string value
+
+T ArrayValue
+P Value values
+
+T ObjectValue
+P ObjectField fields
+
+T ObjectField
+S Name name
+S Value value
+
+T Directive
+S Name name
+P? Argument arguments
+
+U Type
+O NamedType
+O ListType
+O NonNullType
+
+T NamedType
+S Name name
+
+T ListType
+S Type type
+
+T NonNullType
+# JS version prohibits nesting nonnull in nonnull, we can't because we
+# can't support multiple unions. Fix?
+S Type type  
+
+T Name
+S string value
+
+# Implementation of Schema Parser AST Types
+# This is not included in libgraphqlparser.
+# Generated from https://github.com/graphql/graphql-js/blob/master/src/language/ast.js @ 3f1f9f5
+
+U TypeDefinition
+O ObjectTypeDefinition
+O InterfaceTypeDefinition
+O UnionTypeDefinition
+O ScalarTypeDefinition
+O EnumTypeDefinition
+O InputObjectTypeDefinition
+O TypeExtensionDefinition
+
+T ObjectTypeDefinition
+S Name name
+P? NamedType interfaces
+P FieldDefinition fields
+
+T FieldDefinition
+S Name name
+P InputValueDefinition arguments
+S Type type
+
+T InputValueDefinition
+S Name name
+S Type type
+S? Value defaultValue
+
+T InterfaceTypeDefinition
+S Name name
+P FieldDefinition fields
+
+T UnionTypeDefinition
+S Name name
+P NamedType types
+
+T ScalarTypeDefinition
+S Name name
+
+T EnumTypeDefinition
+S Name name
+P EnumValueDefinition values
+
+T EnumValueDefinition
+S Name name
+
+T InputObjectTypeDefinition
+S Name name
+P InputValueDefinition fields
+
+T TypeExtensionDefinition
+S ObjectTypeDefinition definition

--- a/scripts/generate_ast.py
+++ b/scripts/generate_ast.py
@@ -59,6 +59,7 @@ class {name}({parent_type}):'''.format(name=name, parent_type=parent_type)
         self._print_ctor()
         self._print_comparator(typename)
         self._print_repr(typename)
+        self._print_copy(typename)
         self._print_hash()
         self._fields = []
 
@@ -94,6 +95,18 @@ class {name}({parent_type}):'''.format(name=name, parent_type=parent_type)
         ))
         print('            )')
         print('        )')
+
+    def _print_copy(self, typename):
+        fields = (
+            [field for field in self._fields if not field[2]] +
+            [field for field in self._fields if field[2]])
+        args = '\n'.join('''            self.{},'''.format(snake(name)) for (type, name, nullable, plural) in fields)
+        print ('''
+    def __copy__(self):
+        return type(self)(
+{}
+            self.loc
+        )'''.format(args))
 
     def _print_repr(self, typename):
         print('''

--- a/scripts/generate_ast.py
+++ b/scripts/generate_ast.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
     project_root = os.path.join(os.path.dirname(__file__), '..')
     with open(os.path.join(project_root, 'graphql/core/language/ast.py'), 'w') as fp:
         process = subprocess.Popen(
-            ['python', '../libgraphqlparser/ast/ast.py', 'generate_ast', '../libgraphqlparser/ast/ast.ast'],
+            ['python', '../libgraphqlparser/ast/ast.py', 'generate_ast', './ast.ast'],
             stdout=fp,
             cwd=os.path.join(project_root, 'scripts'),
             env={'PYTHONPATH': '.'}

--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setup(
 
     packages=find_packages(exclude=['tests']),
 
-    install_requires=[],
-    tests_require=['pytest>=2.7.3', 'gevent==1.1b5'],
+    install_requires=['six>=1.10.0'],
+    tests_require=['pytest>=2.7.3', 'gevent==1.1b5', 'six>=1.10.0'],
 
     cmdclass={'test': PyTest},
 )

--- a/tests/core_language/fixtures.py
+++ b/tests/core_language/fixtures.py
@@ -44,3 +44,45 @@ fragment frag on Friend {
   query
 }
 """
+
+SCHEMA_KITCHEN_SINK = """
+
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+}
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+union Feed = Story | Article | Advert
+
+scalar CustomScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+"""

--- a/tests/core_language/test_parser.py
+++ b/tests/core_language/test_parser.py
@@ -4,7 +4,7 @@ from graphql.core.language.location import SourceLocation
 from graphql.core.language.source import Source
 from graphql.core.language.parser import parse, Loc
 from graphql.core.language import ast
-from fixtures import KITCHEN_SINK
+from .fixtures import KITCHEN_SINK
 
 
 def test_parse_provides_useful_errors():

--- a/tests/core_language/test_printer.py
+++ b/tests/core_language/test_printer.py
@@ -3,7 +3,7 @@ from graphql.core.language.ast import Field, Name
 from graphql.core.language.parser import parse
 from graphql.core.language.printer import print_ast
 from pytest import raises
-from fixtures import KITCHEN_SINK
+from .fixtures import KITCHEN_SINK
 
 
 def test_does_not_alter_ast():

--- a/tests/core_language/test_schema_parser.py
+++ b/tests/core_language/test_schema_parser.py
@@ -1,0 +1,694 @@
+from pytest import raises
+from graphql.core import Source, parse
+from graphql.core.language import ast
+from graphql.core.language.error import LanguageError
+from graphql.core.language.parser import Loc
+
+
+def create_loc_fn(body):
+    source = Source(body)
+    return lambda start, end: Loc(start, end, source)
+
+
+def test_parses_simple_type():
+    body = '''
+type Hello {
+  world: String
+}'''
+
+    doc = parse(body)
+    loc = create_loc_fn(body)
+
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(23, 29)
+                            ),
+                            loc=loc(23, 29)
+                        ),
+                        loc=loc(16, 29)
+                    )
+                ],
+                loc=loc(1, 31)
+            )
+        ],
+        loc=loc(1, 31)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_extension():
+    body = '''
+extend type Hello {
+  world: String
+}'''
+    doc = parse(body)
+    loc = create_loc_fn(body)
+
+    expected = ast.Document(
+        definitions=[
+            ast.TypeExtensionDefinition(
+                definition=ast.ObjectTypeDefinition(
+                    name=ast.Name(
+                        value='Hello',
+                        loc=loc(13, 18)
+                    ),
+                    interfaces=[],
+                    fields=[
+                        ast.FieldDefinition(
+                            name=ast.Name(
+                                value='world',
+                                loc=loc(23, 28)
+                            ),
+                            arguments=[],
+                            type=ast.NamedType(
+                                name=ast.Name(
+                                    value='String',
+                                    loc=loc(30, 36)
+                                ),
+                                loc=loc(30, 36)
+                            ),
+                            loc=loc(23, 36)
+                        )
+                    ],
+                    loc=loc(8, 38)
+                ),
+                loc=loc(1, 38)
+            )
+        ],
+        loc=loc(1, 38)
+    )
+
+    assert doc == expected
+
+
+def test_simple_non_null_type():
+    body = '''
+type Hello {
+  world: String!
+}'''
+
+    doc = parse(body)
+    loc = create_loc_fn(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[],
+                        type=ast.NonNullType(
+                            type=ast.NamedType(
+                                name=ast.Name(
+                                    value='String',
+                                    loc=loc(23, 29)
+                                ),
+                                loc=loc(23, 29)
+                            ),
+                            loc=loc(23, 30)
+                        ),
+                        loc=loc(16, 30)
+                    )
+                ],
+                loc=loc(1, 32)
+            )
+        ],
+        loc=loc(1, 32)
+    )
+    assert doc == expected
+
+
+def test_parses_simple_type_inheriting_interface():
+    body = 'type Hello implements World { }'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(5, 10)
+                ),
+                interfaces=[
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='World',
+                            loc=loc(22, 27)
+                        ),
+                        loc=loc(22, 27)
+                    )
+                ],
+                fields=[],
+                loc=loc(0, 31)
+            )
+        ],
+        loc=loc(0, 31)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_type_inheriting_multiple_interfaces():
+    body = 'type Hello implements Wo, rld { }'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(5, 10)
+                ),
+                interfaces=[
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='Wo',
+                            loc=loc(22, 24)
+                        ),
+                        loc=loc(22, 24)
+                    ),
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='rld',
+                            loc=loc(26, 29)
+                        ),
+                        loc=loc(26, 29)
+                    )
+                ],
+                fields=[],
+                loc=loc(0, 33)
+            )
+        ],
+        loc=loc(0, 33)
+    )
+    assert doc == expected
+
+
+def test_parses_single_value_enum():
+    body = 'enum Hello { WORLD }'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.EnumTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(5, 10)
+                ),
+                values=[
+                    ast.EnumValueDefinition(
+                        name=ast.Name(
+                            value='WORLD',
+                            loc=loc(13, 18)
+                        ),
+                        loc=loc(13, 18)
+                    )
+                ],
+                loc=loc(0, 20)
+            )
+        ],
+        loc=loc(0, 20)
+    )
+
+    assert doc == expected
+
+
+def test_parses_double_value_enum():
+    body = 'enum Hello { WO, RLD }'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.EnumTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(5, 10)
+                ),
+                values=[
+                    ast.EnumValueDefinition(
+                        name=ast.Name(
+                            value='WO',
+                            loc=loc(13, 15)
+                        ),
+                        loc=loc(13, 15)
+                    ),
+                    ast.EnumValueDefinition(
+                        name=ast.Name(
+                            value='RLD',
+                            loc=loc(17, 20)
+                        ),
+                        loc=loc(17, 20)
+                    )
+                ],
+                loc=loc(0, 22)
+            )
+        ],
+        loc=loc(0, 22)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_interface():
+    body = '''
+interface Hello {
+  world: String
+}
+'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.InterfaceTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(11, 16)
+                ),
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(21, 26)
+                        ),
+                        arguments=[],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(28, 34)
+                            ),
+                            loc=loc(28, 34)
+                        ),
+                        loc=loc(21, 34)
+                    )
+                ],
+                loc=loc(1, 36)
+            )
+        ],
+        loc=loc(1, 37)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_field_with_arg():
+    body = '''
+type Hello {
+  world(flag: Boolean): String
+}'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[
+                            ast.InputValueDefinition(
+                                name=ast.Name(
+                                    value='flag',
+                                    loc=loc(22, 26)
+                                ),
+                                type=ast.NamedType(
+                                    name=ast.Name(
+                                        value='Boolean',
+                                        loc=loc(28, 35)
+                                    ),
+                                    loc=loc(28, 35)
+                                ),
+                                default_value=None,
+                                loc=loc(22, 35)
+                            )
+                        ],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(38, 44)
+                            ),
+                            loc=loc(38, 44)
+                        ),
+                        loc=loc(16, 44)
+                    )
+                ],
+                loc=loc(1, 46)
+            )
+        ],
+        loc=loc(1, 46)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_field_with_arg_with_default_value():
+    body = '''
+type Hello {
+  world(flag: Boolean = true): String
+}'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[
+                            ast.InputValueDefinition(
+                                name=ast.Name(
+                                    value='flag',
+                                    loc=loc(22, 26)
+                                ),
+                                type=ast.NamedType(
+                                    name=ast.Name(
+                                        value='Boolean',
+                                        loc=loc(28, 35)
+                                    ),
+                                    loc=loc(28, 35)
+                                ),
+                                default_value=ast.BooleanValue(
+                                    value=True,
+                                    loc=loc(38, 42)
+                                ),
+                                loc=loc(22, 42)
+                            )
+                        ],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(45, 51)
+                            ),
+                            loc=loc(45, 51)
+                        ),
+                        loc=loc(16, 51)
+                    )
+                ],
+                loc=loc(1, 53)
+            )
+        ],
+        loc=loc(1, 53)
+    )
+
+    assert doc == expected
+
+
+def test_parses_simple_field_with_list_arg():
+    body = '''
+type Hello {
+  world(things: [String]): String
+}'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[
+                            ast.InputValueDefinition(
+                                name=ast.Name(
+                                    value='things',
+                                    loc=loc(22, 28)
+                                ),
+                                type=ast.ListType(
+                                    type=ast.NamedType(
+                                        name=ast.Name(
+                                            value='String',
+                                            loc=loc(31, 37)
+                                        ),
+                                        loc=loc(31, 37)
+                                    ),
+                                    loc=loc(30, 38)
+                                ),
+                                default_value=None,
+                                loc=loc(22, 38)
+                            )
+                        ],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(41, 47)
+                            ),
+                            loc=loc(41, 47)
+                        ),
+                        loc=loc(16, 47)
+                    )
+                ],
+                loc=loc(1, 49)
+            )
+        ],
+        loc=loc(1, 49)
+    )
+    assert doc == expected
+
+
+def test_parses_simple_field_with_two_args():
+    body = '''
+type Hello {
+  world(argOne: Boolean, argTwo: Int): String
+}'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                interfaces=[],
+                fields=[
+                    ast.FieldDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(16, 21)
+                        ),
+                        arguments=[
+                            ast.InputValueDefinition(
+                                name=ast.Name(
+                                    value='argOne',
+                                    loc=loc(22, 28)
+                                ),
+                                type=ast.NamedType(
+                                    name=ast.Name(
+                                        value='Boolean',
+                                        loc=loc(30, 37)
+                                    ),
+                                    loc=loc(30, 37)
+                                ),
+                                default_value=None,
+                                loc=loc(22, 37)
+                            ),
+                            ast.InputValueDefinition(
+                                name=ast.Name(
+                                    value='argTwo',
+                                    loc=loc(39, 45)
+                                ),
+                                type=ast.NamedType(
+                                    name=ast.Name(
+                                        value='Int',
+                                        loc=loc(47, 50)
+                                    ),
+                                    loc=loc(47, 50)
+                                ),
+                                default_value=None,
+                                loc=loc(39, 50)
+                            )
+                        ],
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(53, 59)
+                            ),
+                            loc=loc(53, 59)
+                        ),
+                        loc=loc(16, 59)
+                    )
+                ],
+                loc=loc(1, 61)
+            )
+        ],
+        loc=loc(1, 61)
+    )
+    assert doc == expected
+
+
+def test_parses_simple_union():
+    body = 'union Hello = World'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.UnionTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                types=[
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='World',
+                            loc=loc(14, 19)
+                        ),
+                        loc=loc(14, 19)
+                    )
+                ],
+                loc=loc(0, 19)
+            )
+        ],
+        loc=loc(0, 19)
+    )
+    assert doc == expected
+
+
+def test_parses_union_with_two_types():
+    body = 'union Hello = Wo | Rld'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.UnionTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(6, 11)
+                ),
+                types=[
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='Wo',
+                            loc=loc(14, 16)
+                        ),
+                        loc=loc(14, 16)
+                    ),
+                    ast.NamedType(
+                        name=ast.Name(
+                            value='Rld',
+                            loc=loc(19, 22)
+                        ),
+                        loc=loc(19, 22)
+                    )
+                ],
+                loc=loc(0, 22)
+            )
+        ],
+        loc=loc(0, 22)
+    )
+    assert doc == expected
+
+
+def test_parses_scalar():
+    body = 'scalar Hello'
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.ScalarTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(7, 12)
+                ),
+                loc=loc(0, 12)
+            )
+        ],
+        loc=loc(0, 12)
+    )
+    assert doc == expected
+
+
+def test_parses_simple_input_object():
+    body = '''
+input Hello {
+  world: String
+}'''
+    loc = create_loc_fn(body)
+    doc = parse(body)
+    expected = ast.Document(
+        definitions=[
+            ast.InputObjectTypeDefinition(
+                name=ast.Name(
+                    value='Hello',
+                    loc=loc(7, 12)
+                ),
+                fields=[
+                    ast.InputValueDefinition(
+                        name=ast.Name(
+                            value='world',
+                            loc=loc(17, 22)
+                        ),
+                        type=ast.NamedType(
+                            name=ast.Name(
+                                value='String',
+                                loc=loc(24, 30)
+                            ),
+                            loc=loc(24, 30)
+                        ),
+                        default_value=None,
+                        loc=loc(17, 30)
+                    )
+                ],
+                loc=loc(1, 32)
+            )
+        ],
+        loc=loc(1, 32)
+    )
+    assert doc == expected
+
+
+def test_parsing_simple_input_object_with_args_should_fail():
+    body = '''
+input Hello {
+  world(foo: Int): String
+}
+'''
+    with raises(LanguageError) as excinfo:
+        parse(body)
+
+    assert 'Syntax Error GraphQL (3:8) Expected :, found (' in excinfo.value.message

--- a/tests/core_language/test_schema_printer.py
+++ b/tests/core_language/test_schema_printer.py
@@ -1,0 +1,69 @@
+from copy import deepcopy
+from graphql.core import parse
+from pytest import raises
+from graphql.core.language.printer import print_ast
+from graphql.core.language import ast
+from .fixtures import SCHEMA_KITCHEN_SINK
+
+
+def test_prints_minimal_ast():
+    node = ast.ScalarTypeDefinition(
+        name=ast.Name('foo')
+    )
+
+    assert print_ast(node) == 'scalar foo'
+
+
+def test_print_produces_helpful_error_messages():
+    bad_ast = {'random': 'Data'}
+    with raises(AssertionError) as excinfo:
+        print_ast(bad_ast)
+
+    assert "Invalid AST Node: {'random': 'Data'}" in str(excinfo.value)
+
+
+def test_does_not_alter_ast():
+    ast = parse(SCHEMA_KITCHEN_SINK)
+    ast_copy = deepcopy(ast)
+    print_ast(ast)
+    assert ast == ast_copy
+
+
+def test_prints_kitchen_sink():
+    ast = parse(SCHEMA_KITCHEN_SINK)
+    printed = print_ast(ast)
+
+    expected = '''type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+}
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+union Feed = Story | Article | Advert
+
+scalar CustomScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+'''
+
+    assert printed == expected

--- a/tests/core_language/test_visitor.py
+++ b/tests/core_language/test_visitor.py
@@ -1,7 +1,7 @@
 from graphql.core.language.ast import Field, Name, SelectionSet
 from graphql.core.language.parser import parse
 from graphql.core.language.visitor import visit, Visitor, REMOVE, BREAK
-from fixtures import KITCHEN_SINK
+from .fixtures import KITCHEN_SINK
 
 
 def test_allows_for_editing_on_enter():

--- a/tests/core_utils/test_ast_to_code.py
+++ b/tests/core_utils/test_ast_to_code.py
@@ -1,0 +1,15 @@
+from graphql.core import parse, Source
+from graphql.core.language.parser import Loc
+from graphql.core.language import ast
+from graphql.core.utils.ast_to_code import ast_to_code
+from tests.core_language import fixtures
+
+
+def test_ast_to_code_using_kitchen_sink():
+    doc = parse(fixtures.KITCHEN_SINK)
+    code_ast = ast_to_code(doc)
+    source = Source(fixtures.KITCHEN_SINK)
+    loc = lambda start, end: Loc(start, end, source)
+
+    parsed_code_ast = eval(code_ast, {}, {'ast': ast, 'loc': loc})
+    assert doc == parsed_code_ast

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = flake8,import-order,py27,py33,py34,py35,pypy,docs
 deps =
     pytest>=2.7.2
     gevent==1.1b5
+    six>=1.10.0
 commands =
     py{27,33,34,py}: py.test tests {posargs}
     py35: py.test tests tests_py35 {posargs}


### PR DESCRIPTION
PR for issue #11
- Adds the schema type definitions to ast.ast to have generate_ast() generate classes for them.
- parse_type_definition will now parse schema types.
- Implement parsers for each schema type.
- Improve error message in `Executor.complete_value` when runtime type doesn't match.
- Implement more missing executor tests.
- The `visit` function will no longer attempt to deep copy nodes when there is an edit. Shallow copies are perfectly acceptable, since we are only overwriting attributes on edit.
- The `Visitor` class now pre-calculates an AST Type to Handler map in the metaclass, allowing for a much quicker enter/leave implementation.
- Install `six`.
- Use `VisitorMeta` to power `TypeInfo` so that it's not a huge isinstance chain.

Checklist to merge:
- [X] Implement remaining schema parser tests.
- [x] Implement schema printer and tests.
