### PR TITLE
Instead of using is_nullish, use a more Pythonic "is None" check.

### DIFF
--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -8,7 +8,6 @@ from ..language.parser import parse
 from ..language.source import Source
 from ..type import GraphQLEnumType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, \
     GraphQLScalarType, GraphQLUnionType
-from ..utils.is_nullish import is_nullish
 from ..validation import validate
 from .base import ExecutionContext, ExecutionResult, ResolveInfo, Undefined, collect_fields, default_resolve_fn, \
     get_argument_values, get_field_def, get_operation_root_type
@@ -224,7 +223,7 @@ class Executor(object):
             return completed
 
         # If result is null-like, return null.
-        if is_nullish(result):
+        if result is None:
             return None
 
         # If field type is List, complete each item in the list with the inner type
@@ -248,7 +247,7 @@ class Executor(object):
         if isinstance(return_type, (GraphQLScalarType, GraphQLEnumType)):
             serialized_result = return_type.serialize(result)
 
-            if is_nullish(serialized_result):
+            if serialized_result is None:
                 return None
 
             return serialized_result

--- a/graphql/core/utils/ast_from_value.py
+++ b/graphql/core/utils/ast_from_value.py
@@ -11,14 +11,13 @@ from ..type.definition import (
     GraphQLNonNull,
 )
 from ..type.scalars import GraphQLFloat
-from .is_nullish import is_nullish
 
 
 def ast_from_value(value, type=None):
     if isinstance(type, GraphQLNonNull):
         return ast_from_value(value, type.of_type)
 
-    if is_nullish(value):
+    if value is None:
         return None
 
     if isinstance(value, list):

--- a/graphql/core/utils/is_nullish.py
+++ b/graphql/core/utils/is_nullish.py
@@ -1,2 +1,0 @@
-def is_nullish(value):
-    return value is None or value != value

--- a/graphql/core/utils/is_valid_literal_value.py
+++ b/graphql/core/utils/is_valid_literal_value.py
@@ -6,7 +6,6 @@ from ..type.definition import (
     GraphQLNonNull,
     GraphQLScalarType,
 )
-from .is_nullish import is_nullish
 
 
 def is_valid_literal_value(type, value_ast):
@@ -49,4 +48,4 @@ def is_valid_literal_value(type, value_ast):
 
     assert isinstance(type, (GraphQLScalarType, GraphQLEnumType)), 'Must be input type'
 
-    return not is_nullish(type.parse_literal(value_ast))
+    return type.parse_literal(value_ast) is not None

--- a/graphql/core/utils/is_valid_value.py
+++ b/graphql/core/utils/is_valid_value.py
@@ -11,18 +11,17 @@ from ..type import (
     GraphQLNonNull,
     GraphQLScalarType,
 )
-from .is_nullish import is_nullish
 
 
 def is_valid_value(type, value):
     """Given a type and any value, return True if that value is valid."""
     if isinstance(type, GraphQLNonNull):
-        if is_nullish(value):
+        if value is None:
             return False
 
         return is_valid_value(type.of_type, value)
 
-    if is_nullish(value):
+    if value is None:
         return True
 
     if isinstance(type, GraphQLList):
@@ -54,4 +53,4 @@ def is_valid_value(type, value):
 
     # Scalar/Enum input checks to ensure the type can parse the value to
     # a non-null value.
-    return not is_nullish(type.parse_value(value))
+    return type.parse_value(value) is not None

--- a/graphql/core/utils/schema_printer.py
+++ b/graphql/core/utils/schema_printer.py
@@ -8,7 +8,6 @@ from ..type.definition import (
     GraphQLUnionType
 )
 from .ast_from_value import ast_from_value
-from .is_nullish import is_nullish
 
 
 def print_schema(schema):
@@ -118,7 +117,7 @@ def _print_args(field):
 
 
 def _print_input_value(arg):
-    if not is_nullish(arg.default_value):
+    if arg.default_value is not None:
         default_value = ' = ' + print_ast(ast_from_value(arg.default_value, arg.type))
     else:
         default_value = ''

--- a/graphql/core/utils/value_from_ast.py
+++ b/graphql/core/utils/value_from_ast.py
@@ -1,6 +1,5 @@
 from ..language import ast
 from ..type import (GraphQLEnumType, GraphQLInputObjectType, GraphQLList, GraphQLNonNull, GraphQLScalarType)
-from .is_nullish import is_nullish
 
 
 def value_from_ast(value_ast, type, variables=None):
@@ -63,8 +62,4 @@ def value_from_ast(value_ast, type, variables=None):
     assert isinstance(type, (GraphQLScalarType, GraphQLEnumType)), \
         'Must be input type'
 
-    parsed = type.parse_literal(value_ast)
-    if not is_nullish(parsed):
-        return parsed
-
-    return None
+    return type.parse_literal(value_ast)

--- a/tests/core_utils/test_schema_printer.py
+++ b/tests/core_utils/test_schema_printer.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 from graphql.core.type.definition import GraphQLField, GraphQLArgument, GraphQLInputObjectField, GraphQLEnumValue
 from graphql.core.utils.schema_printer import print_schema, print_introspection_schema
-from graphql.core.utils.is_nullish import is_nullish
-from graphql.core.language.printer import print_ast
 from graphql.core.type import (
     GraphQLSchema,
     GraphQLInputObjectType,


### PR DESCRIPTION
As discussed previously, since NaN does not enter the codebase in the Python implementation, we don't have to have a (non-pythonic, better would be `math.isnan`) check for it in `is_nullish`. Replace `is_nullish` with `is` comparison with `None`.
