### PR TITLE
Add option to specify `map_type` in the Executor.

### DIFF
--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -15,9 +15,21 @@ from .base import ExecutionContext, ExecutionResult, ResolveInfo, Undefined, col
 
 
 class Executor(object):
-    def __init__(self, execution_middlewares=None, default_resolver=default_resolve_fn):
-        self.execution_middlewares = execution_middlewares or []
-        self.default_resolve_fn = default_resolver
+    def __init__(self, execution_middlewares=None, default_resolver=default_resolve_fn, map_type=dict):
+        assert issubclass(map_type, collections.MutableMapping)
+
+        self._execution_middlewares = execution_middlewares or []
+        self._default_resolve_fn = default_resolver
+        self._map_type = map_type
+        self._enforce_strict_ordering = issubclass(map_type, collections.OrderedDict)
+
+    @property
+    def enforce_strict_ordering(self):
+        return self._enforce_strict_ordering
+
+    @property
+    def map_type(self):
+        return self._map_type
 
     def execute(self, schema, request='', root=None, args=None, operation_name=None, request_context=None,
                 execute_serially=False, validate_ast=True):
@@ -34,7 +46,7 @@ class Executor(object):
             validate_ast
         )
 
-        for middleware in self.execution_middlewares:
+        for middleware in self._execution_middlewares:
             if hasattr(middleware, 'execution_result'):
                 curried_execution_function = functools.partial(middleware.execution_result, curried_execution_function)
 
@@ -81,7 +93,10 @@ class Executor(object):
         if operation.operation == 'mutation' or execute_serially:
             execute_serially = True
 
-        fields = DefaultOrderedDict(list) if execute_serially else collections.defaultdict(list)
+        fields = DefaultOrderedDict(list) \
+            if (execute_serially or self._enforce_strict_ordering) \
+            else collections.defaultdict(list)
+
         fields = collect_fields(ctx, type, operation.selection_set, fields, set())
 
         if execute_serially:
@@ -109,12 +124,12 @@ class Executor(object):
         def execute_field(prev_deferred, response_name):
             return prev_deferred.add_callback(execute_field_callback, response_name)
 
-        return functools.reduce(execute_field, fields.keys(), succeed({}))
+        return functools.reduce(execute_field, fields.keys(), succeed(self._map_type()))
 
     def _execute_fields(self, execution_context, parent_type, source_value, fields):
         contains_deferred = False
 
-        results = {}
+        results = self._map_type()
         for response_name, field_asts in fields.items():
             result = self._resolve_field(execution_context, parent_type, source_value, field_asts)
             if result is Undefined:
@@ -138,7 +153,7 @@ class Executor(object):
             return Undefined
 
         return_type = field_def.type
-        resolve_fn = field_def.resolver or self.default_resolve_fn
+        resolve_fn = field_def.resolver or self._default_resolve_fn
 
         # Build a dict of arguments from the field.arguments AST, using the variables scope to
         # fulfill any variable references.
@@ -283,7 +298,7 @@ class Executor(object):
             )
 
         # Collect sub-fields to execute to complete this value.
-        subfield_asts = collections.defaultdict(list)
+        subfield_asts = DefaultOrderedDict(list) if self._enforce_strict_ordering else collections.defaultdict(list)
         visited_fragment_names = set()
         for field_ast in field_asts:
             selection_set = field_ast.selection_set
@@ -298,7 +313,7 @@ class Executor(object):
         curried_resolve_fn = functools.partial(resolve_fn, source, args, info)
 
         try:
-            for middleware in self.execution_middlewares:
+            for middleware in self._execution_middlewares:
                 if hasattr(middleware, 'run_resolve_fn'):
                     curried_resolve_fn = functools.partial(middleware.run_resolve_fn, curried_resolve_fn, resolve_fn)
 

--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -116,7 +116,7 @@ class Executor(object):
                 return results
 
             if isinstance(result, Deferred):
-                return result.add_callback(collect_result)
+                return succeed(result).add_callback(collect_result)
 
             else:
                 return collect_result(result)

--- a/graphql/core/pyutils/defer.py
+++ b/graphql/core/pyutils/defer.py
@@ -472,13 +472,13 @@ class _ResultCollector(Deferred):
         self._result = result
         for key, value in items:
             if isinstance(value, Deferred):
-                value.add_callbacks(self._cb_deferred, self._cb_deferred,
-                                    callback_args=(key, True),
-                                    errback_args=(key, False))
-
                 # We will place a value in place of the resolved key, so that insert order is preserved.
                 if preserve_insert_ordering:
                     result[key] = None
+
+                value.add_callbacks(self._cb_deferred, self._cb_deferred,
+                                    callback_args=(key, True),
+                                    errback_args=(key, False))
             else:
                 self.objects_remaining_to_resolve -= 1
                 result[key] = value

--- a/graphql/core/pyutils/defer.py
+++ b/graphql/core/pyutils/defer.py
@@ -466,7 +466,7 @@ class _ResultCollector(Deferred):
     objects_remaining_to_resolve = 0
     _result = None
 
-    def _schedule_callbacks(self, items, result, objects_remaining_to_resolve=None):
+    def _schedule_callbacks(self, items, result, objects_remaining_to_resolve=None, preserve_insert_ordering=False):
         self.objects_remaining_to_resolve = \
             objects_remaining_to_resolve if objects_remaining_to_resolve is not None else len(items)
         self._result = result
@@ -476,6 +476,9 @@ class _ResultCollector(Deferred):
                                     callback_args=(key, True),
                                     errback_args=(key, False))
 
+                # We will place a value in place of the resolved key, so that insert order is preserved.
+                if preserve_insert_ordering:
+                    result[key] = None
             else:
                 self.objects_remaining_to_resolve -= 1
                 result[key] = value
@@ -509,7 +512,8 @@ class DeferredDict(_ResultCollector):
     def __init__(self, mapping):
         super(DeferredDict, self).__init__()
         assert isinstance(mapping, collections.Mapping)
-        self._schedule_callbacks(mapping.items(), {})
+        self._schedule_callbacks(mapping.items(), type(mapping)(),
+                                 preserve_insert_ordering=isinstance(mapping, collections.OrderedDict))
 
 
 class DeferredList(_ResultCollector):

--- a/graphql/core/utils/build_ast_schema.py
+++ b/graphql/core/utils/build_ast_schema.py
@@ -68,7 +68,6 @@ def build_ast_schema(document, query_type_name, mutation_type_name=None):
 
     def produce_type_def(type_ast):
         type_name = _get_inner_type_name(type_ast)
-        print('ptd', type_name)
         if type_name in inner_type_map:
             return _build_wrapped_type(inner_type_map[type_name], type_ast)
 

--- a/tests/core_execution/test_executor.py
+++ b/tests/core_execution/test_executor.py
@@ -474,10 +474,10 @@ def test_executor_can_enforce_strict_ordering():
 
     data = result.data
     assert isinstance(data, OrderedDict)
-    assert data.keys() == ['a', 'b', 'c', 'aa', 'cc', 'bb', 'aaz', 'bbz', 'deep', 'ccz', 'zzz', 'aaa']
+    assert list(data.keys()) == ['a', 'b', 'c', 'aa', 'cc', 'bb', 'aaz', 'bbz', 'deep', 'ccz', 'zzz', 'aaa']
     deep = data['deep']
     assert isinstance(deep, OrderedDict)
-    assert deep.keys() == ['b', 'a', 'c', 'deeper']
+    assert list(deep.keys()) == ['b', 'a', 'c', 'deeper']
     deeper = deep['deeper']
     assert isinstance(deeper, OrderedDict)
-    assert deeper.keys() == ['c', 'a', 'b']
+    assert list(deeper.keys()) == ['c', 'a', 'b']


### PR DESCRIPTION
If map_type is a subclass of `collections.OrderedDict`, it then strict key ordering will be enforced.
