### PR TITLE
Adding exception loggging

### DIFF
--- a/graphql/core/execution/executor.py
+++ b/graphql/core/execution/executor.py
@@ -1,5 +1,6 @@
 import collections
 import functools
+import logging
 
 from ..error import GraphQLError
 from ..language import ast
@@ -12,6 +13,9 @@ from ..type import GraphQLEnumType, GraphQLInterfaceType, GraphQLList, GraphQLNo
 from ..validation import validate
 from .base import ExecutionContext, ExecutionResult, ResolveInfo, Undefined, collect_fields, default_resolve_fn, \
     get_field_def, get_operation_root_type
+
+
+logger = logging.getLogger(__name__)
 
 
 class Executor(object):
@@ -316,4 +320,5 @@ class Executor(object):
 
             return curried_resolve_fn()
         except Exception as e:
+            logger.info(e, exc_info=True)
             return e


### PR DESCRIPTION
The error reporting code swallows exceptions in order to report them to the client. When debugging (and when getting started with graphql as I am) it is very useful to be able to see the exception stack traces.

I have therefore added a single logging statement to `Executor.run_resolve_fn()`. Is it possible that logging is also required elsewhere, I'm happy to take any advice this.
