### PR TITLE
Allow merging of types when one is an interface for the other

### DIFF
--- a/graphql/core/validation/rules/overlapping_fields_can_be_merged.py
+++ b/graphql/core/validation/rules/overlapping_fields_can_be_merged.py
@@ -72,7 +72,7 @@ class OverlappingFieldsCanBeMerged(ValidationRule):
         type1 = def1 and def1.type
         type2 = def2 and def2.type
 
-        if type1 and type2 and not self.same_type(type1, type2):
+        if type1 and type2 and not self.same_type(type1, type2) and not self.is_interface_implementation(type1, type2) and not self.is_interface_implementation(type2, type1):
             return (
                 (response_name, 'they return differing types {} and {}'.format(type1, type2)),
                 [ast1],
@@ -160,6 +160,16 @@ class OverlappingFieldsCanBeMerged(ValidationRule):
                 return False
 
         return True
+
+    @staticmethod
+    def is_interface_implementation(value1, value2):
+        type1, type2 = get_named_type(value1), get_named_type(value2)
+
+        if isinstance(type2, GraphQLInterfaceType) and isinstance(type1, GraphQLObjectType):
+            for interface in type1.get_interfaces():
+                if interface.is_same_type(type2):
+                    return True
+        return False
 
     def collect_field_asts_and_defs(self, parent_type, selection_set, visited_fragment_names=None, ast_and_defs=None):
         if visited_fragment_names is None:

--- a/graphql/core/validation/rules/overlapping_fields_can_be_merged.py
+++ b/graphql/core/validation/rules/overlapping_fields_can_be_merged.py
@@ -72,7 +72,9 @@ class OverlappingFieldsCanBeMerged(ValidationRule):
         type1 = def1 and def1.type
         type2 = def2 and def2.type
 
-        if type1 and type2 and not self.same_type(type1, type2) and not self.is_interface_implementation(type1, type2) and not self.is_interface_implementation(type2, type1):
+        if type1 and type2 and not self.same_type(type1, type2) and \
+                not self.is_interface_implementation(type1, type2) and \
+                not self.is_interface_implementation(type2, type1):
             return (
                 (response_name, 'they return differing types {} and {}'.format(type1, type2)),
                 [ast1],


### PR DESCRIPTION
The first issue I mentioned in https://github.com/graphql-python/graphql-core/issues/48 is fixed in the latest version (thanks!).

I think this fixes the second issue, which it turns out I couldn't easily work around it. I'm not 100% certain this is a valid thing to do so I won't be offended if you reject this pull request!
