### PR TITLE
Editing a node on both enter and leave

### DIFF
--- a/graphql/core/language/tests/test_visitor.py
+++ b/graphql/core/language/tests/test_visitor.py
@@ -1,4 +1,4 @@
-from graphql.core.language.ast import Field, Name, SelectionSet
+from graphql.core.language.ast import Field, Name, SelectionSet, Document, OperationDefinition
 from graphql.core.language.parser import parse
 from graphql.core.language.printer import print_ast
 from graphql.core.language.visitor import (
@@ -8,6 +8,67 @@ from graphql.core.type import is_composite_type, get_named_type
 
 from .fixtures import KITCHEN_SINK
 from ...validation.tests.utils import test_schema
+
+
+def test_allows_editing_a_node_both_on_enter_and_on_leave():
+    ast = parse('{ a, b, c { a, b, c } }', no_location=True)
+
+    class TestVisitor(Visitor):
+        def enter(self, node, *args):
+            if isinstance(node, OperationDefinition):
+                selection_set = node.selection_set
+                self.selections = None
+                if selection_set:
+                    self.selections = selection_set.selections
+                new_selection_set = SelectionSet(
+                    selections=[])
+                return OperationDefinition(
+                    name=node.name,
+                    variable_definitions=node.variable_definitions,
+                    directives=node.directives,
+                    loc=node.loc,
+                    operation=node.operation,
+                    selection_set=new_selection_set)
+
+        def leave(self, node, *args):
+            if isinstance(node, OperationDefinition):
+                new_selection_set = None
+                if self.selections:
+                    new_selection_set = SelectionSet(
+                        selections=self.selections)
+                return OperationDefinition(
+                    name=node.name,
+                    variable_definitions=node.variable_definitions,
+                    directives=node.directives,
+                    loc=node.loc,
+                    operation=node.operation,
+                    selection_set=new_selection_set)
+
+    edited_ast = visit(ast, TestVisitor())
+    assert ast == parse('{ a, b, c { a, b, c } }', no_location=True)
+    assert edited_ast == ast
+
+
+def test_allows_editing_the_root_node_on_enter_and_on_leave():
+    ast = parse('{ a, b, c { a, b, c } }', no_location=True)
+
+    definitions = ast.definitions
+
+    class TestVisitor(Visitor):
+        def enter(self, node, *args):
+            if isinstance(node, Document):
+                return Document(
+                    loc=node.loc,
+                    definitions=[])
+
+        def leave(self, node, *args):
+            if isinstance(node, Document):
+                return Document(
+                    loc=node.loc,
+                    definitions=definitions)
+
+    edited_ast = visit(ast, TestVisitor())
+    assert edited_ast == ast
 
 
 def test_allows_for_editing_on_enter():

--- a/graphql/core/language/visitor.py
+++ b/graphql/core/language/visitor.py
@@ -153,7 +153,7 @@ def visit(root, visitor, key_map=None):
             break
 
     if edits:
-        new_root = edits[0][1]
+        new_root = edits[-1][1]
 
     return new_root
 


### PR DESCRIPTION
Starting small - I've just grabbed the first commits from GraphQL-js that haven't been ported yet and ported them:

https://github.com/graphql/graphql-js/commit/42562305570b04a5b7ec1ee7714f020f366023c9
https://github.com/graphql/graphql-js/commit/f79ba42e30d9f1380f378440e4fe66b1aa428386

I've just dived in without a particularly deep knowledge of the codebase so I hope I haven't screwed it up. If I'm wasting your time I'll stop! If you're happy with this approach I can comment on https://github.com/graphql-python/graphql-core/issues/53 to let you know which commits I'm working on and keep going through them.
