### PR TITLE
Add test for parseLiteral on ComplexScalar

### DIFF
--- a/graphql/execution/tests/test_variables.py
+++ b/graphql/execution/tests/test_variables.py
@@ -141,6 +141,19 @@ def test_does_not_use_incorrect_value():
     })
 
 
+def test_properly_runs_parse_literal_on_complex_scalar_types():
+    doc = '''
+    {
+        fieldWithObjectInput(input: {a: "foo", d: "SerializedValue"})
+    }
+    '''
+    check(doc, {
+        'data': {
+            'fieldWithObjectInput': '{"a": "foo", "d": "DeserializedValue"}',
+        }
+    })
+
+
 # noinspection PyMethodMayBeStatic
 class TestUsingVariables:
     doc = '''


### PR DESCRIPTION
Related GraphQL-js commit: https://github.com/graphql/graphql-js/commit/b3a512787618cfbed20c9717daf2d69444bf7f33

IMPORTANT NOTE: I ported this exactly and the tests didn't pass - I had to modify the spacing here https://github.com/graphql/graphql-js/commit/b3a512787618cfbed20c9717daf2d69444bf7f33#diff-64eca043c22a2e544421f7d3c3f2f751R189
I don't know the codebase well enough yet to know if this is acceptable or not so don't merge if it's highlighted a bug!
