### PR TITLE
Error handling more closely as graphql-js

### DIFF
--- a/graphql/core/error/__init__.py
+++ b/graphql/core/error/__init__.py
@@ -1,0 +1,3 @@
+from .graphql_error import GraphQLError, format_error
+
+__all__ = ['GraphQLError', 'format_error']

--- a/graphql/core/error/graphql_error.py
+++ b/graphql/core/error/graphql_error.py
@@ -1,20 +1,16 @@
-from .language.location import get_location
+from ..language.location import get_location
 
 
-class Error(Exception):
-    pass
+class GraphQLError(Exception):
+    __slots__ = 'message', 'nodes', '_source', '_positions', 'original_error'
 
-
-class GraphQLError(Error):
-    __slots__ = 'message', 'nodes', 'stack', '_source', '_positions'
-
-    def __init__(self, message, nodes=None, stack=None, source=None, positions=None):
+    def __init__(self, message, nodes=None, source=None, positions=None, original_error=None):
         super(GraphQLError, self).__init__(message)
         self.message = message or 'An unknown error occurred.'
         self.nodes = nodes
-        self.stack = stack or message
         self._source = source
         self._positions = positions
+        self.original_error = original_error
 
     @property
     def source(self):

--- a/graphql/core/validation/rules/unique_argument_names.py
+++ b/graphql/core/validation/rules/unique_argument_names.py
@@ -1,4 +1,4 @@
-from ...error import GraphQLError
+from ...error.graphql_error import GraphQLError
 from .base import ValidationRule
 
 

--- a/graphql/core/validation/rules/unique_operation_names.py
+++ b/graphql/core/validation/rules/unique_operation_names.py
@@ -1,4 +1,4 @@
-from ...error import GraphQLError
+from ...error.graphql_error import GraphQLError
 from .base import ValidationRule
 
 

--- a/graphql/core/validation/rules/variables_are_input_types.py
+++ b/graphql/core/validation/rules/variables_are_input_types.py
@@ -1,4 +1,4 @@
-from ...error import GraphQLError
+from ...error.graphql_error import GraphQLError
 from ...language.printer import print_ast
 from ...type.definition import is_input_type
 from ...utils.type_from_ast import type_from_ast

--- a/tests/core_execution/test_executor.py
+++ b/tests/core_execution/test_executor.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 from pytest import raises
 
-from graphql.core.error import GraphQLError
+from graphql.core.error.graphql_error import GraphQLError
 from graphql.core.execution import Executor, execute
 from graphql.core.execution.middlewares.sync import \
     SynchronousExecutionMiddleware

--- a/tests/core_execution/test_variables.py
+++ b/tests/core_execution/test_variables.py
@@ -2,7 +2,7 @@ import json
 
 from pytest import raises
 
-from graphql.core.error import GraphQLError, format_error
+from graphql.core.error.graphql_error import GraphQLError, format_error
 from graphql.core.execution import execute
 from graphql.core.language.parser import parse
 from graphql.core.type import (GraphQLArgument, GraphQLField,

--- a/tests/core_utils/test_extend_schema.py
+++ b/tests/core_utils/test_extend_schema.py
@@ -102,6 +102,7 @@ def test_cannot_be_used_for_execution():
     clientQuery = parse('{ newField }')
 
     result = execute(extended_schema, object(), clientQuery)
+    print(result)
     assert result.data['newField'] is None
     assert str(result.errors[0]
                ) == 'Client Schema cannot be used for execution.'


### PR DESCRIPTION
I added the `original_error` attribute as per graphql-js and now raising the `GraphQLError` with the previous stack as that what it seems the js code is intending. 

I haven't tested yet if that works in the actual app so I am not entirely sure this will work given that we do this `ctx.errors.append(e)`. In py3 it seems there is a `__traceback__` on any `Exception` but not in py2. So I wouldn't even be sure how to best handle it cross-version otherwise.

Anyway, this is my first go at this implementation, might revise when I actually get to test it out etc.
