### PR TITLE
Add right stack trace to exception

### DIFF
--- a/graphql/error/located_error.py
+++ b/graphql/error/located_error.py
@@ -13,7 +13,10 @@ class GraphQLLocatedError(GraphQLError):
         else:
             message = 'An unknown error occurred.'
 
-        stack = original_error.stack
+        if hasattr(original_error, 'stack'):
+            stack = original_error.stack
+        else:
+            stack = sys.exc_info()[2]
 
         super(GraphQLLocatedError, self).__init__(
             message=message,

--- a/graphql/error/located_error.py
+++ b/graphql/error/located_error.py
@@ -13,10 +13,7 @@ class GraphQLLocatedError(GraphQLError):
         else:
             message = 'An unknown error occurred.'
 
-        if isinstance(original_error, GraphQLError):
-            stack = original_error.stack
-        else:
-            stack = sys.exc_info()[2]
+        stack = original_error.stack
 
         super(GraphQLLocatedError, self).__init__(
             message=message,

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -1,6 +1,7 @@
 import collections
 import functools
 import logging
+import sys
 
 from promise import Promise, is_thenable, promise_for_dict, promisify
 
@@ -170,6 +171,7 @@ def resolve_or_error(resolve_fn, source, args, context, info, executor):
         logger.exception("An error occurred while resolving field {}.{}".format(
             info.parent_type.name, info.field_name
         ))
+        e.stack = sys.exc_info()[2]
         return e
 
 


### PR DESCRIPTION
Just in the progress of upgrading to the new graphql version and loving most of the things :)

I just noticed that at the point we store the stack trace on the located error it is not the same as the original error anymore (at least on python 2). This fixed it on my local machine for our project.
