### PR TITLE
Use promise.get() instead of promise.value in executor

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -51,7 +51,7 @@ def execute(schema, document_ast, root_value=None, context_value=None,
 
     p = Promise(executor).catch(on_rejected).then(on_resolve)
     context.executor.wait_until_finished()
-    return p.value
+    return p.get()
 
 
 def execute_operation(exe_context, operation, root_value):


### PR DESCRIPTION
This small change allows for resolvers to return Promises and still get resolved properly using the `SyncExecutor`.

This small change combined with https://github.com/syrusakbary/promise/pull/1 increases the performance in our app quite a bit for 'free'.
