### PR TITLE
inline fragment bug fix: use more precise type comparaison than native python object equality

### DIFF
--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -228,7 +228,7 @@ def does_fragment_condition_match(ctx, fragment, type_):
         return True
 
     conditional_type = type_from_ast(ctx.schema, type_condition_ast)
-    if conditional_type == type_:
+    if conditional_type.is_same_type(type_):
         return True
 
     if isinstance(conditional_type, (GraphQLInterfaceType, GraphQLUnionType)):


### PR DESCRIPTION
python version: 3.4.3+

I make this pull request because graphql-core can't resolve fields requested from an inline fragment.

Here is my graphiql query:

```
{
  bundle(identifier: "30752cba-f3a7-49c8-b6c7-afa6a9579a1c") {
    name
    ... on Issue {
      mid
    }
  }
}
```

And here is the result:

```
{
  "data": {
    "bundle": {
      "name": "bundle 1"
    }
  }
}
```

We can see that mid field requested on Issue is not resolved.

I saw in graphql-core code that a check is made on the type provided in the query by the inline fragment (in my case Issue) againt type returned by schema usage at runtime (so it is Issue too).

file: graphql/execution/base.py
line: 225

``` python
    def does_fragment_condition_match(ctx, fragment, type_):
        type_condition_ast = fragment.type_condition
        if not type_condition_ast:
            return True

        conditional_type = type_from_ast(ctx.schema, type_condition_ast)
        if conditional_type == type_:
            return True

        if isinstance(conditional_type, (GraphQLInterfaceType, GraphQLUnionType)):
            return ctx.schema.is_possible_type(conditional_type, type_)

        return False
```

So in my case, evaluation of this test: if conditional_type == type_ returns False in spite of types being equals.

To be sure of that i have printed it:
    print(type(conditional_type)) => class 'graphql.type.definition.GraphQLObjectType'
    print(type(type_)) => class 'graphql.type.definition.GraphQLObjectType'
    print(conditional_type.name) => Issue
    print(type_.name) => Issue

Fortunately i found a method on parent class of GraphQLObjectType that does exactly what is expected:
file: graphql/type/definition.py
line: 85

``` python
    def is_same_type(self, other):
        return self.__class__ is other.__class__ and self.name == other.name
```

For information:

Here is my schema:

``` python
@schema.register
class Bundle(graphene.Interface):
    id = graphene.ID()
    identifier = graphene.String()
    name = graphene.String()

    @classmethod
    def _resolve_type(cls, schema, instance, *args):
        if instance.mid is not None:
            return Issue.internal_type(schema)
        return Bundle.internal_type(schema)

@schema.register
class Issue(Bundle):
    mid = graphene.String()

class Query(graphene.ObjectType):
    bundle = graphene.Field('Bundle', identifier=graphene.String())

    def resolve_bundle(self, args, info):
        filters = {}
        filters[get_model_field_name('Bundle', 'identifier')] = args.get('identifier')
        return get_model('Bundle').query.filter_by(**filters)\
                                        .options(load_only(*get_root_fields('Bundle', info)))\
                                        .one()
```

Thanks a lot for your awesome work on this project.
