### PR TITLE
Move test dependencies to extras_require

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For questions, ask [Stack Overflow](http://stackoverflow.com/questions/tagged/gr
 An overview of the GraphQL language is available in the 
 [README](https://github.com/facebook/graphql/blob/master/README.md) for the
 [Specification for GraphQL](https://github.com/facebook/graphql). 
-The overview describes a simple set of GraphQL examples that exist as [tests](tests/core_starwars)
+The overview describes a simple set of GraphQL examples that exist as [tests](tests/starwars)
 in this repository. A good way to get started is to walk through that README and the corresponding tests
 in parallel. 
 
@@ -62,7 +62,7 @@ schema = GraphQLSchema(
 This defines a simple schema with one type and one field, that resolves
 to a fixed value. The `resolve` function can return a value, a promise,
 or an array of promises. A more complex example is included in the top
-level [tests](graphql/tests) directory.
+level [tests](tests) directory.
 
 Then, serve the result of a query against that type schema.
 

--- a/graphql/graphql.py
+++ b/graphql/graphql.py
@@ -1,7 +1,7 @@
 from .execution import ExecutionResult, execute
+from .language.ast import Document
 from .language.parser import parse
 from .language.source import Source
-from .language.ast import Document
 from .validation import validate
 
 

--- a/graphql/graphql.py
+++ b/graphql/graphql.py
@@ -1,6 +1,7 @@
 from .execution import ExecutionResult, execute
 from .language.parser import parse
 from .language.source import Source
+from .language.ast import Document
 from .validation import validate
 
 
@@ -30,8 +31,11 @@ def graphql(schema, request_string='', root_value=None, context_value=None,
             variable_values=None, operation_name=None, executor=None,
             return_promise=False):
     try:
-        source = Source(request_string, 'GraphQL request')
-        ast = parse(source)
+        if isinstance(request_string, Document):
+            ast = request_string
+        else:
+            source = Source(request_string, 'GraphQL request')
+            ast = parse(source)
         validation_errors = validate(schema, ast)
         if validation_errors:
             return ExecutionResult(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setup(
         'pytest>=2.7.3',
         'gevent==1.1rc1',
         'six>=1.10.0',
-        'pytest-mock'
+        'pytest-mock',
+        'promise>=0.4.2'
     ],
     extras_require={
         'gevent': [

--- a/setup.py
+++ b/setup.py
@@ -47,16 +47,16 @@ setup(
         'six>=1.10.0',
         'promise>=0.4.2'
     ],
-    tests_require=[
-        'pytest>=2.7.3',
-        'gevent==1.1rc1',
-        'six>=1.10.0',
-        'pytest-mock',
-        'promise>=0.4.2'
-    ],
     extras_require={
         'gevent': [
             'gevent==1.1rc1'
+        ],
+        'test': [
+            'pytest>=2.7.3',
+            'gevent==1.1rc1',
+            'six>=1.10.0',
+            'pytest-mock',
+            'promise>=0.4.2'
         ]
     }
 )


### PR DESCRIPTION
Having dependencies in `tests_require` is not very useful. Moving them to `extras_require` allows installation with `pip install 'graphql-core[test]'`. See [here](https://github.com/pypa/pip/issues/1197#issuecomment-228939212).
