### PR TITLE
Add __repr__ and __str__ to ExecutionResult

### DIFF
--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from ..error import GraphQLError
+import json
+import six
+
+from ..error import GraphQLError, format_error
 from ..language import ast
 from ..type.definition import GraphQLInterfaceType, GraphQLUnionType
 from ..type.directives import GraphQLIncludeDirective, GraphQLSkipDirective
@@ -100,6 +103,29 @@ class ExecutionResult(object):
                 self.invalid == other.invalid
             )
         )
+
+    def __repr__(self):
+        return str(self.response)
+
+    def __str__(self):
+        return json.dumps(self.response)
+
+    @staticmethod
+    def _format_error(error):
+        if isinstance(error, GraphQLError):
+            return format_error(error)
+        return {'message': six.text_type(error)}
+
+    @property
+    def response(self):
+        """Returns the object as a GraphQL response.
+        https://facebook.github.io/graphql/#sec-Response"""
+        response = {}
+        if self.data and not self.invalid:
+            response['data'] = dict(self.data)
+        if self.errors:
+            response['errors'] = [self._format_error(e) for e in self.errors]
+        return response
 
 
 def get_operation_root_type(schema, operation):

--- a/graphql/execution/tests/test_execute_schema.py
+++ b/graphql/execution/tests/test_execute_schema.py
@@ -209,7 +209,7 @@ def test_execution_result():
 
     # __repr__ and __str__
     result = ExecutionResult(data={'foo': 'bar'}, errors=['foo', 'bar'])
-    assert "'data': {'foo': 'bar'}" in repr(result)
-    assert "'errors': [{'message': 'foo'}, {'message': 'bar'}]" in repr(result)
-    assert '"data": {"foo": "bar"}' in str(result)
-    assert '"errors": [{"message": "foo"}, {"message": "bar"}]' in str(result)
+    assert "'data'" in repr(result)
+    assert "'errors'" in repr(result)
+    assert '"data"' in str(result)
+    assert '"errors"' in str(result)

--- a/graphql/execution/tests/test_execute_schema.py
+++ b/graphql/execution/tests/test_execute_schema.py
@@ -1,4 +1,4 @@
-from graphql.execution import execute
+from graphql.execution import execute, ExecutionResult
 from graphql.language.parser import parse
 from graphql.type import (GraphQLArgument, GraphQLBoolean, GraphQLField,
                           GraphQLID, GraphQLInt, GraphQLList, GraphQLNonNull,
@@ -185,3 +185,31 @@ def test_executes_using_a_schema():
                 }
             }
         }
+
+
+def test_execution_result():
+
+    # Success
+    assert ExecutionResult(data={'foo': 'bar'}).response == \
+        {'data': {'foo': 'bar'}}
+
+    # Error
+    assert ExecutionResult(errors=['foo', 'bar']).response == \
+        {'errors': [{'message': 'foo'}, {'message': 'bar'}]}
+
+    # Partial success
+    assert ExecutionResult(data={'foo': 'bar'}, errors=['foo', 'bar']).response == \
+        {'data': {'foo': 'bar'}, 'errors': [{'message': 'foo'}, {'message': 'bar'}]}
+
+    # No arguments
+    assert ExecutionResult().response == {}
+
+    # Invalid
+    assert ExecutionResult(invalid=True).response == {}
+
+    # __repr__ and __str__
+    result = ExecutionResult(data={'foo': 'bar'}, errors=['foo', 'bar'])
+    assert "'data': {'foo': 'bar'}" in repr(result)
+    assert "'errors': [{'message': 'foo'}, {'message': 'bar'}]" in repr(result)
+    assert '"data": {"foo": "bar"}' in str(result)
+    assert '"errors": [{"message": "foo"}, {"message": "bar"}]' in str(result)


### PR DESCRIPTION
Gives nicer feedback when working in the repl

``` python
>>> schema.execute('{hello}')
{'data': {'hello': 'World'}}
```

And easily get the result as a json-encoded string

``` python
>>> str(schema.execute('{hello}'))
'{"data": {"hello": "World"}}'
```
