### PR TITLE
Bring back pre-parsing support

### DIFF
--- a/graphql/graphql.py
+++ b/graphql/graphql.py
@@ -1,4 +1,5 @@
 from .execution import ExecutionResult, execute
+from .language.ast import Document
 from .language.parser import parse
 from .language.source import Source
 from .validation import validate

--- a/graphql/graphql.py
+++ b/graphql/graphql.py
@@ -30,8 +30,11 @@ def graphql(schema, request_string='', root_value=None, context_value=None,
             variable_values=None, operation_name=None, executor=None,
             return_promise=False, middleware=None):
     try:
-        source = Source(request_string, 'GraphQL request')
-        ast = parse(source)
+        if isinstance(request_string, Document):
+            ast = request_string
+        else:
+            source = Source(request_string, 'GraphQL request')
+            ast = parse(source)
         validation_errors = validate(schema, ast)
         if validation_errors:
             return ExecutionResult(


### PR DESCRIPTION
It seems that when merging `1.0` into master it has overwritten the functionality provided in https://github.com/graphql-python/graphql-core/pull/73

This brings that functionality back.

On a side node, a new `1.0.1` release with that would be much appreciated :)
