### PR TITLE
Default resolve uses dict key if source value is dict

### DIFF
--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -285,10 +285,14 @@ class ResolveInfo(object):
 
 
 def default_resolve_fn(source, args, context, info):
-    """If a resolve function is not given, then a default resolve behavior is used which takes the property of the source object
+    """If a resolve function is not given, then a default resolve behavior is used which takes the property of the source object or dict
     of the same name as the field and returns it as the result, or if it's a function, returns the result of calling that function."""
     name = info.field_name
-    property = getattr(source, name, None)
+    property = None
+    if hasattr(source, name):
+        property = getattr(source, name)
+    elif type(source) is dict:
+        property = source.get(name)
     if callable(property):
         return property()
     return property

--- a/graphql/execution/tests/test_resolve.py
+++ b/graphql/execution/tests/test_resolve.py
@@ -190,3 +190,10 @@ def test_maps_argument_out_names_well_with_input():
     assert result.data == {
         'test': '["Source!",{"a_input":{"input_recursive":{"input_one":"SourceRecursive!"}}}]'
     }
+
+
+def test_default_resolve_works_with_dicts():
+    schema = _test_schema(GraphQLField(GraphQLString))
+    result = graphql(schema, '{ test }', {'test': 'testValue'})
+    assert not result.errors
+    assert result.data == {'test': 'testValue'}


### PR DESCRIPTION
If the source value is a `dict` it seemed like this would make sense as the default behavior, and I was actually surprised it wasn't the default. So I figured I'd open it up for discussion, at least to figure out if this was an oversight or if this was intentionally excluded.