### PR TITLE
Support subclasses of Promise

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_promise(obj):
-    return type(obj) == Promise
+    return isinstance(obj, Promise)
 
 
 def execute(schema, document_ast, root_value=None, context_value=None,


### PR DESCRIPTION
Allow `is_promise` to return true if the object is a subclass of `Promise`. Allows for user-extended `Promise` classes to be used.