### PR TITLE
Accept custom middleware on experimental executor

### DIFF
--- a/graphql/execution/experimental/executor.py
+++ b/graphql/execution/experimental/executor.py
@@ -16,6 +16,9 @@ def execute(schema, document_ast, root_value=None, context_value=None,
         'not multiple versions of GraphQL installed in your node_modules directory.'
     )
     if middleware:
+        if not isinstance(middleware, MiddlewareManager):
+            middleware = MiddlewareManager(*middleware)
+            
         assert isinstance(middleware, MiddlewareManager), (
             'middlewares have to be an instance'
             ' of MiddlewareManager. Received "{}".'.format(middleware)

--- a/graphql/execution/experimental/executor.py
+++ b/graphql/execution/experimental/executor.py
@@ -18,7 +18,6 @@ def execute(schema, document_ast, root_value=None, context_value=None,
     if middleware:
         if not isinstance(middleware, MiddlewareManager):
             middleware = MiddlewareManager(*middleware)
-            
         assert isinstance(middleware, MiddlewareManager), (
             'middlewares have to be an instance'
             ' of MiddlewareManager. Received "{}".'.format(middleware)


### PR DESCRIPTION
Other option would be making middleware verification that happens on #L47[https://github.com/graphql-python/graphql-core/blob/features/next-query-builder/graphql/execution/executor.py#L47] before calling the experimental executor on #L36[https://github.com/graphql-python/graphql-core/blob/features/next-query-builder/graphql/execution/executor.py#L36]