### PR TITLE
Handle printing queries with integer arguments

### DIFF
--- a/graphql/language/printer.py
+++ b/graphql/language/printer.py
@@ -47,7 +47,7 @@ class PrintingVisitor(Visitor):
         ], ' ')
 
     def leave_Argument(self, node, *args):
-        return node.name + ': ' + node.value
+        return '{0.name}: {0.value}'.format(node)
 
     # Fragments
 


### PR DESCRIPTION
The GitHub v4 API uses integer argument for paging. Without this patch, the code would attempt to run (essentially) `"last" + ": " + 10`, which isn't valid in Python.

With this change, an argument value of `.args(last=10)` is correctly pretty-printed as `(last: 10)`.