### PR TITLE
Reraise exceptions while doing parallel resolution

### DIFF
--- a/graphql/execution/executors/utils.py
+++ b/graphql/execution/executors/utils.py
@@ -4,3 +4,4 @@ def process(p, f, args, kwargs):
         p.do_resolve(val)
     except Exception as e:
         p.do_reject(e)
+        raise


### PR DESCRIPTION
If I get an exception while in the context of the gevent loop,
I lose the stacktrace. This is because the exception is being
caught in order to (properly) reject the promise representing
the async work but not being reraised. The only signal to the
developer something went wrong is the exception message
presented in the graphql response.

I fixed this by reraising after rejecting the promise.

@syrusakbary Is there a more proper way to do this?