### PR TITLE
Fix a small problem in the TypeInfo utility class

### DIFF
--- a/graphql/utils/type_info.py
+++ b/graphql/utils/type_info.py
@@ -148,7 +148,7 @@ class TypeInfo(object):
         self._argument = None
         pop(self._input_type_stack)
 
-    def leave_ListType(self):
+    def leave_ListValue(self):
         pop(self._input_type_stack)
 
-    leave_ObjectField = leave_ListType
+    leave_ObjectField = leave_ListValue


### PR DESCRIPTION
It checks for list values, so the leave method should be suffixed
ListValue, not ListType. The enter method has the proper name.