### PR TITLE
Fix #104 - memory leak in AsyncioExecutor when return_promise=True

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -49,6 +49,8 @@ def execute(schema, document_ast, root_value=None, context_value=None,
     if executor is None:
         executor = SyncExecutor()
 
+    executor.return_promise = return_promise
+
     context = ExecutionContext(
         schema,
         document_ast,

--- a/graphql/execution/executors/asyncio.py
+++ b/graphql/execution/executors/asyncio.py
@@ -43,6 +43,7 @@ class AsyncioExecutor(object):
             loop = get_event_loop()
         self.loop = loop
         self.futures = []
+        self.return_promise = False
 
     def wait_until_finished(self):
         # if there are futures to wait for
@@ -56,7 +57,8 @@ class AsyncioExecutor(object):
         result = fn(*args, **kwargs)
         if isinstance(result, Future) or iscoroutine(result):
             future = ensure_future(result, loop=self.loop)
-            self.futures.append(future)
+            if not self.return_promise:
+                self.futures.append(future)
             return Promise.resolve(future)
         elif isasyncgen(result):
             return asyncgen_to_observable(result)


### PR DESCRIPTION
`AsyncioExecutor` makes `self.futures.append(future)` for each resolver,
but cleans this list in `wait_until_finished()` only, which is called only when `return_promise=False`.

However, `return_promise=True` is the only way to use `AsyncioExecutor` when asyncio loop is already running.
Without `return_promise=True` it will raise exception "this event loop is already running" by calling `loop.run_until_complete()` from `wait_until_finished()`.

Bad workaround is to create new `AsyncioExecutor()` instance for each request in hope that old one would be garbage collected with its useless `self.futures` list.
Another bad workaround is to clear `executor.futures` manually, which breaks encapsulation of knowledge about internals of `AsyncioExecutor`.

This PR fixes initial issue by avoiding `self.futures.append(future)` for the case of `return_promise=True`.