### PR TITLE
Update enum tests

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -437,10 +437,15 @@ def complete_leaf_value(return_type, result):
     """
     Complete a Scalar or Enum by serializing to a valid value, returning null if serialization is not possible.
     """
-    # serialize = getattr(return_type, 'serialize', None)
-    # assert serialize, 'Missing serialize method on type'
+    assert hasattr(return_type, 'serialize'), 'Missing serialize method on type'
+    serialized_result = return_type.serialize(result)
 
-    return return_type.serialize(result)
+    if serialized_result is None:
+        raise GraphQLError(
+            ('Expected a value of type "{}" but ' +
+             'received: {}').format(return_type, result)
+        )
+    return serialized_result
 
 
 def complete_abstract_value(exe_context, return_type, field_asts, info, result):

--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -406,6 +406,12 @@ class GraphQLEnumType(GraphQLType):
 
         self.values = define_enum_values(self, values)
 
+    def getValues(self):
+        return self.values
+
+    def getValue(self, name):
+        return self._name_lookup.get(name)
+
     def serialize(self, value):
         if isinstance(value, collections.Hashable):
             enum_value = self._value_lookup.get(value)
@@ -456,7 +462,7 @@ def define_enum_values(type, value_map):
         )
         value = copy.copy(value)
         value.name = value_name
-        if value.value is None:
+        if value.value == Undefined:
             value.value = value_name
 
         values.append(value)
@@ -464,14 +470,20 @@ def define_enum_values(type, value_map):
     return values
 
 
-class GraphQLEnumValue(object):
-    __slots__ = 'name', 'value', 'deprecation_reason', 'description'
+class Undefined(object):
+    """A representation of an Undefined value distinct from a None value"""
+    pass
 
-    def __init__(self, value=None, deprecation_reason=None, description=None, name=None):
+
+class GraphQLEnumValue(object):
+    __slots__ = 'name', 'value', 'is_deprecated', 'deprecation_reason', 'description'
+
+    def __init__(self, value=Undefined, deprecation_reason=None, description=None, name=None):
         self.name = name
         self.value = value
         self.deprecation_reason = deprecation_reason
         self.description = description
+        self.is_deprecated = bool(deprecation_reason)
 
     def __eq__(self, other):
         return (

--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -406,10 +406,10 @@ class GraphQLEnumType(GraphQLType):
 
         self.values = define_enum_values(self, values)
 
-    def getValues(self):
+    def get_values(self):
         return self.values
 
-    def getValue(self, name):
+    def get_value(self, name):
         return self._name_lookup.get(name)
 
     def serialize(self, value):
@@ -476,14 +476,17 @@ class Undefined(object):
 
 
 class GraphQLEnumValue(object):
-    __slots__ = 'name', 'value', 'is_deprecated', 'deprecation_reason', 'description'
+    __slots__ = 'name', 'value', 'deprecation_reason', 'description'
 
     def __init__(self, value=Undefined, deprecation_reason=None, description=None, name=None):
         self.name = name
         self.value = value
         self.deprecation_reason = deprecation_reason
         self.description = description
-        self.is_deprecated = bool(deprecation_reason)
+
+    @property
+    def is_deprecated(self):
+        return bool(self.deprecation_reason)
 
     def __eq__(self, other):
         return (

--- a/graphql/type/tests/test_definition.py
+++ b/graphql/type/tests/test_definition.py
@@ -122,7 +122,7 @@ def test_defines_an_enum_type_with_deprecated_value():
     EnumTypeWithDeprecatedValue = GraphQLEnumType('EnumWithDeprecatedValue', {
         'foo': GraphQLEnumValue(deprecation_reason='Just because'),
     })
-    value = EnumTypeWithDeprecatedValue.getValues()[0]
+    value = EnumTypeWithDeprecatedValue.get_values()[0]
     assert value.name == 'foo'
     assert value.description is None
     assert value.is_deprecated is True
@@ -135,7 +135,7 @@ def test_defines_an_enum_type_with_a_value_of_none():
         'NULL': GraphQLEnumValue(None),
     })
 
-    value = EnumTypeWithNoneValue.getValues()[0]
+    value = EnumTypeWithNoneValue.get_values()[0]
     assert value.name == 'NULL'
     assert value.description is None
     assert value.is_deprecated is False

--- a/graphql/type/tests/test_definition.py
+++ b/graphql/type/tests/test_definition.py
@@ -118,6 +118,31 @@ def test_defines_a_subscription_schema():
     # assert subscription.name == 'articleSubscribe'
 
 
+def test_defines_an_enum_type_with_deprecated_value():
+    EnumTypeWithDeprecatedValue = GraphQLEnumType('EnumWithDeprecatedValue', {
+        'foo': GraphQLEnumValue(deprecation_reason='Just because'),
+    })
+    value = EnumTypeWithDeprecatedValue.getValues()[0]
+    assert value.name == 'foo'
+    assert value.description is None
+    assert value.is_deprecated is True
+    assert value.deprecation_reason == 'Just because'
+    assert value.value == 'foo'
+
+
+def test_defines_an_enum_type_with_a_value_of_none():
+    EnumTypeWithNoneValue = GraphQLEnumType('EnumWithNullishValue', {
+        'NULL': GraphQLEnumValue(None),
+    })
+
+    value = EnumTypeWithNoneValue.getValues()[0]
+    assert value.name == 'NULL'
+    assert value.description is None
+    assert value.is_deprecated is False
+    assert value.deprecation_reason is None
+    assert value.value is None
+
+
 def test_includes_nested_input_objects_in_the_map():
     NestedInputObject = GraphQLInputObjectType(
         name='NestedInputObject',

--- a/graphql/type/tests/test_definition.py
+++ b/graphql/type/tests/test_definition.py
@@ -161,6 +161,23 @@ def test_includes_nested_input_objects_in_the_map():
     assert schema.get_type_map()['NestedInputObject'] is NestedInputObject
 
 
+def test_includes_interface_possible_types_in_the_type_map():
+    SomeInterface = GraphQLInterfaceType('SomeInterface', fields={'f': GraphQLField(GraphQLInt)})
+    SomeSubtype = GraphQLObjectType(
+        name='SomeSubtype',
+        fields={'f': GraphQLField(GraphQLInt)},
+        interfaces=[SomeInterface],
+        is_type_of=lambda: None
+    )
+    schema = GraphQLSchema(
+        query=GraphQLObjectType(
+            name='Query',
+            fields={
+                'iface': GraphQLField(SomeInterface)}),
+        types=[SomeSubtype])
+    assert schema.get_type_map()['SomeSubtype'] == SomeSubtype
+
+
 def test_includes_interfaces_thunk_subtypes_in_the_type_map():
     SomeInterface = GraphQLInterfaceType(
         name='SomeInterface',
@@ -186,23 +203,6 @@ def test_includes_interfaces_thunk_subtypes_in_the_type_map():
     ), types=[SomeSubtype])
 
     assert schema.get_type_map()['SomeSubtype'] is SomeSubtype
-
-
-def test_includes_interfaces_subtypes_in_the_type_map():
-    SomeInterface = GraphQLInterfaceType('SomeInterface', fields={'f': GraphQLField(GraphQLInt)})
-    SomeSubtype = GraphQLObjectType(
-        name='SomeSubtype',
-        fields={'f': GraphQLField(GraphQLInt)},
-        interfaces=[SomeInterface],
-        is_type_of=lambda: None
-    )
-    schema = GraphQLSchema(
-        query=GraphQLObjectType(
-            name='Query',
-            fields={
-                'iface': GraphQLField(SomeInterface)}),
-        types=[SomeSubtype])
-    assert schema.get_type_map()['SomeSubtype'] == SomeSubtype
 
 
 def test_stringifies_simple_types():

--- a/graphql/type/tests/test_enum_type.py
+++ b/graphql/type/tests/test_enum_type.py
@@ -212,6 +212,26 @@ def test_enum_inputs_may_be_nullable():
     assert result.data == {'colorEnum': None, 'colorInt': None}
 
 
+def test_presents_a_getValues_api():
+    values = ColorType.getValues()
+    assert len(values) == 3
+    assert values[0].name == 'RED'
+    assert values[0].value == 0
+    assert values[1].name == 'GREEN'
+    assert values[1].value == 1
+    assert values[2].name == 'BLUE'
+    assert values[2].value == 2
+
+
+def test_presents_a_getValue_api():
+    oneValue = ColorType.getValue('RED')
+    assert oneValue.name == 'RED'
+    assert oneValue.value == 0
+
+    badUsage = ColorType.getValue(0)
+    assert badUsage is None
+
+
 def test_sorts_values_if_not_using_ordered_dict():
     enum = GraphQLEnumType(name='Test', values={
         'c': GraphQLEnumValue(),

--- a/graphql/type/tests/test_enum_type.py
+++ b/graphql/type/tests/test_enum_type.py
@@ -212,8 +212,8 @@ def test_enum_inputs_may_be_nullable():
     assert result.data == {'colorEnum': None, 'colorInt': None}
 
 
-def test_presents_a_getValues_api():
-    values = ColorType.getValues()
+def test_presents_a_get_values_api():
+    values = ColorType.get_values()
     assert len(values) == 3
     assert values[0].name == 'RED'
     assert values[0].value == 0
@@ -223,12 +223,12 @@ def test_presents_a_getValues_api():
     assert values[2].value == 2
 
 
-def test_presents_a_getValue_api():
-    oneValue = ColorType.getValue('RED')
+def test_presents_a_get_value_api():
+    oneValue = ColorType.get_value('RED')
     assert oneValue.name == 'RED'
     assert oneValue.value == 0
 
-    badUsage = ColorType.getValue(0)
+    badUsage = ColorType.get_value(0)
     assert badUsage is None
 
 

--- a/graphql/type/tests/test_enum_type.py
+++ b/graphql/type/tests/test_enum_type.py
@@ -127,11 +127,11 @@ def test_does_not_accept_values_with_incorrect_casing():
                                        'Expected type "Color", found green.'
 
 
-# TODO
 def test_does_not_accept_incorrect_internal_value():
     result = graphql(Schema, '{ colorEnum(fromString: "GREEN") }')
     assert result.data == {'colorEnum': None}
-    assert result.errors[0].messages == ''
+    assert result.errors[0].message == 'Expected a value of type "Color" ' \
+                                       'but received: GREEN'
 
 
 def test_does_not_accept_internal_value_in_place_of_enum_literal():


### PR DESCRIPTION
Update enum tests to bring them inline with graphql-js v0.13.1

I've not included the complex value tests since I'm not sure how it can be achieved in Python. 