### PR TITLE
Use exc_info keyword when logging an exception.

### DIFF
--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-from traceback import format_exception
 
 from ..error import GraphQLError
 from ..language import ast
@@ -145,10 +144,8 @@ class ExecutionContext(object):
 
     def report_error(self, error, traceback=None):
         # type: (Exception, Optional[TracebackType]) -> None
-        exception = format_exception(
-            type(error), error, getattr(error, "stack", None) or traceback
-        )
-        logger.error("".join(exception))
+        info = (type(error), error, getattr(error, "stack", None) or traceback)
+        logger.error("%s", error, exc_info=info)
         self.errors.append(error)
 
     def get_sub_fields(self, return_type, field_asts):


### PR DESCRIPTION
An improvement of my older PR https://github.com/graphql-python/graphql-core/pull/154 which replaced `sys.excepthook` with the logging module.
Instead of manually formating the exception use the `exc_info` keyword to let the logging library handle the formatting, and properly set the `exc_info` property of the log record.

As @tlinhart pointed out in https://github.com/graphql-python/graphql-core/issues/142 with the current implementation is difficult to filter which exceptions are logged. 

This allows easier filtering of exceptions. Example:
```py
class Filter(logging.Filter):
    def filter(self, record):
        if record.exc_info:
            exception = record.exc_info[1]
            # exception is an instance of `GraphQLLocatedError`, the original error is in the property `original_error`
            return not isinstance(exception.original_error, IgnoredException)
        return True

logging.getLogger('graphql.execution.base').addFilter(Filter())
```