### PR TITLE
Add dict support for the default resolver

### DIFF
--- a/graphql/execution/tests/test_resolve.py
+++ b/graphql/execution/tests/test_resolve.py
@@ -224,3 +224,10 @@ def test_maps_argument_out_names_well_with_input():
     assert result.data == {
         "test": '["Source!",{"a_input":{"input_recursive":{"input_one":"SourceRecursive!"}}}]'
     }
+
+
+def test_default_resolve_works_with_dicts():
+    schema = _test_schema(GraphQLField(GraphQLString))
+    result = graphql(schema, "{ test }", {"test": "testValue"})
+    assert not result.errors
+    assert result.data == {"test": "testValue"}

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -345,11 +345,14 @@ def get_field_entry_key(node):
 
 
 def default_resolve_fn(source, info, **args):
-    # type: (Any, ResolveInfo, **Any) -> Union[int, str]
+    # type: (Any, ResolveInfo, **Any) -> Optional[Any]
     """If a resolve function is not given, then a default resolve behavior is used which takes the property of the source object
     of the same name as the field and returns it as the result, or if it's a function, returns the result of calling that function."""
     name = info.field_name
-    property = getattr(source, name, None)
+    if isinstance(source, dict):
+        property = source.get(name)
+    else:
+        property = getattr(source, name, None)
     if callable(property):
         return property()
     return property


### PR DESCRIPTION
Closes #103 and graphql-python/graphene#638

`graphql-js` handles this case as expected and now using the python port for work I was surprised to see the default resolver lacked this feature. Using dict literals in resolvers is much more convenient than creating a namedtuple for everything.

@syrusakbary please consider merging this, from the linked issues it seems I'm not alone in this feeling.