### PR TITLE
Add `is_deprecated` property to GraphQLField

### DIFF
--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -261,6 +261,10 @@ class GraphQLField(object):
     def __hash__(self):
         return id(self)
 
+    @property
+    def is_deprecated(self):
+        return bool(self.deprecation_reason)
+
 
 class GraphQLArgument(object):
     __slots__ = 'type', 'default_value', 'description', 'out_name'

--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -195,6 +195,9 @@ def define_field_map(type, field_map):
 
     for field_name, field in field_map.items():
         assert_valid_name(field_name)
+        assert isinstance(field, GraphQLField), (
+            '{}.{} must be an instance of GraphQLField.'.format(type, field_name)
+        )
         field_args = getattr(field, 'args', None)
 
         if field_args:

--- a/graphql/type/tests/test_definition.py
+++ b/graphql/type/tests/test_definition.py
@@ -118,6 +118,23 @@ def test_defines_a_subscription_schema():
     # assert subscription.name == 'articleSubscribe'
 
 
+def test_defines_an_object_type_with_deprecated_field():
+    TypeWithDeprecatedField = GraphQLObjectType('foo', fields={
+        'bar': GraphQLField(
+            type=GraphQLString,
+            deprecation_reason='A terrible reason'
+        ),
+    })
+
+    field = TypeWithDeprecatedField.fields['bar']
+    assert field.type == GraphQLString
+    assert field.description is None
+    assert field.deprecation_reason == 'A terrible reason'
+    assert field.is_deprecated is True
+    # assert field.name == 'bar'
+    assert field.args == OrderedDict()
+
+
 def test_includes_nested_input_objects_in_the_map():
     NestedInputObject = GraphQLInputObjectType(
         name='NestedInputObject',

--- a/graphql/type/typemap.py
+++ b/graphql/type/typemap.py
@@ -2,7 +2,7 @@ from collections import OrderedDict, Sequence, defaultdict
 from functools import reduce
 
 from ..utils.type_comparators import is_equal_type, is_type_sub_type_of
-from .definition import (GraphQLArgument, GraphQLField,
+from .definition import (GraphQLArgument,
                          GraphQLInputObjectField, GraphQLInputObjectType,
                          GraphQLInterfaceType, GraphQLList, GraphQLNonNull,
                          GraphQLObjectType, GraphQLUnionType, is_input_type,
@@ -87,9 +87,6 @@ class GraphQLTypeMap(OrderedDict):
                         '{}.{} field type must be Input Type but got: {}.'.format(type, field_name, field.type)
                     )
                 else:
-                    assert isinstance(field, (GraphQLField, GraphQLField)), (
-                        '{}.{} must be an instance of GraphQLField.'.format(type, field_name)
-                    )
                     assert is_output_type(field.type), (
                         '{}.{} field type must be Output Type but got: {}.'.format(type, field_name, field.type)
                     )


### PR DESCRIPTION
Also moved part of the field validation to be more inline with how graphql-js does it.