### PR TITLE
Add document path equivalent to path to ResolveInfo

### DIFF
--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -298,10 +298,11 @@ def get_field_entry_key(node):
 
 class ResolveInfo(object):
     __slots__ = ('field_name', 'field_asts', 'return_type', 'parent_type',
-                 'schema', 'fragments', 'root_value', 'operation', 'variable_values', 'context', 'path')
+                 'schema', 'fragments', 'root_value', 'operation', 'variable_values',
+                 'context', 'path', 'document_path')
 
     def __init__(self, field_name, field_asts, return_type, parent_type,
-                 schema, fragments, root_value, operation, variable_values, context, path):
+                 schema, fragments, root_value, operation, variable_values, context, path, document_path):
         self.field_name = field_name
         self.field_asts = field_asts
         self.return_type = return_type
@@ -313,6 +314,7 @@ class ResolveInfo(object):
         self.variable_values = variable_values
         self.context = context
         self.path = path
+        self.document_path = document_path
 
 
 def default_resolve_fn(source, info, **args):


### PR DESCRIPTION
This extends the behavior introduced in #148 by adding a document path to `ResolveInfo`, ie. the path as the final response will see it, such that it is possible to refer to a path equivalent to the aliased path. This serves to make it possible to use the path to describe error paths in custom error messages.

Further, this copies the `ResolveInfo` with the updated paths for list element iteration, to avoid mutating the `ResolveInfo` of the field as well as to prevent race issues between list elements accessing the path in promises.