### PR TITLE
Consistently translate Python enumerations to values

### DIFF
--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -551,7 +551,10 @@ class GraphQLEnumType(GraphQLNamedType):
     @cached_property
     def _value_lookup(self):
         # type: () -> Dict[str, GraphQLEnumValue]
-        return {value.value: value for value in self.values}
+        return {
+            value.value.value if isinstance(value.value, PyEnum) else value.value: value
+            for value in self.values
+        }
 
     @cached_property
     def _name_lookup(self):

--- a/graphql/type/tests/test_serialization.py
+++ b/graphql/type/tests/test_serialization.py
@@ -81,3 +81,24 @@ def test_serializes_enum():
     assert enum_type.serialize(Color.RED.value) == "RED"
     assert enum_type.serialize(Color.EXTRA) is None
     assert enum_type.serialize(Color.EXTRA.value) is None
+
+
+def test_serialize_enum_pyenum():
+    class Color(Enum):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
+        EXTRA = 4
+
+    enum_type = GraphQLEnumType(
+        "Color",
+        values={
+            "RED": GraphQLEnumValue(Color.RED),
+            "GREEN": GraphQLEnumValue(Color.GREEN),
+            "BLUE": GraphQLEnumValue(Color.BLUE),
+        },
+    )
+    assert enum_type.serialize(Color.RED) == "RED"
+    assert enum_type.serialize(Color.RED.value) == "RED"
+    assert enum_type.serialize(Color.EXTRA) is None
+    assert enum_type.serialize(Color.EXTRA.value) is None


### PR DESCRIPTION
First off, thank you very much for the hard work on this. It's very appreciated!

We use Python enumeration values as the internally represented value for our GraphQL enumerations for a number of reasons. The recent change of coercing Python enumeration values to their internal values before lookup in `GraphQLEnumType.serialize` means that 2.1.0 broke the ability to do this.

This should fix the issue by forcing the same value-ification in the lookup dictionary to make it consistent.