### PR TITLE
Fix a typo in a deprecation warning

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -84,7 +84,7 @@ def execute(
         context = options["context_value"]
     if variables is None and "variable_values" in options:
         warnings.warn(
-            "variable_values has been deprecated. Please use values=... instead.",
+            "variable_values has been deprecated. Please use variables=... instead.",
             category=DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
The deprecation warning says :
```"variable_values has been deprecated. Please use values=... instead.",```
But, the key argument written here should be `variables` and not `values`, as it is written above at line 85 : 
```if variables is None and "variable_values" in options:```