### PR TITLE
Add `extensions` property to GraphQLError.

### DIFF
--- a/graphql/error/base.py
+++ b/graphql/error/base.py
@@ -6,7 +6,7 @@ if False:  # flake8: noqa
     from ..language.source import Source
     from ..language.location import SourceLocation
     from types import TracebackType
-    from typing import Optional, List, Any, Union
+    from typing import Optional, List, Any, Union, Dict
 
 
 class GraphQLError(Exception):
@@ -30,6 +30,7 @@ class GraphQLError(Exception):
         positions=None,  # type: Optional[Any]
         locations=None,  # type: Optional[Any]
         path=None,  # type: Union[List[Union[int, str]], List[str], None]
+        extensions=None # type: Optional[Dict[str, Any]]
     ):
         # type: (...) -> None
         super(GraphQLError, self).__init__(message)
@@ -40,6 +41,7 @@ class GraphQLError(Exception):
         self._positions = positions
         self._locations = locations
         self.path = path
+        self.extensions = extensions
         return None
 
     @property

--- a/graphql/error/format_error.py
+++ b/graphql/error/format_error.py
@@ -17,5 +17,7 @@ def format_error(error):
             ]
         if error.path is not None:
             formatted_error["path"] = error.path
+        if error.extensions is not None:
+            formatted_error["extensions"] = error.extensions
 
     return formatted_error


### PR DESCRIPTION
Allows an `extensions` property to be passed when creating a GraphQLError as described in https://github.com/graphql-python/graphql-core/issues/203. 

This property is included in [`graphql-js`](https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js#L30), which makes `graphql-python` more accurately reflect it. 