### PR TITLE
Support for resolver ExecutionResult return type (aka extensions support)

### DIFF
--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -60,6 +60,9 @@ class ExecutionResult(object):
         if not self.invalid:
             response["data"] = self.data
 
+        if self.extensions:
+            response["extensions"] = self.extensions
+
         return response
 
 

--- a/graphql/execution/base.py
+++ b/graphql/execution/base.py
@@ -76,6 +76,7 @@ class ResolveInfo(object):
         "variable_values",
         "context",
         "path",
+        "extensions",
     )
 
     def __init__(
@@ -91,6 +92,7 @@ class ResolveInfo(object):
         variable_values,  # type: Dict
         context,  # type: Optional[Any]
         path=None,  # type: Union[List[Union[int, str]], List[str]]
+        extensions=None,  # type: Dict
     ):
         # type: (...) -> None
         self.field_name = field_name
@@ -104,6 +106,7 @@ class ResolveInfo(object):
         self.variable_values = variable_values
         self.context = context
         self.path = path
+        self.extensions = extensions
 
 
 __all__ = [

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -541,10 +541,11 @@ def complete_value(
         if extensions:
             exe_context.update_extensions(extensions)
         if errors:
-            exe_context.report_error(error) for error in errors
+            for error in errors:
+                exe_context.report_error(error) 
 
         return complete_value(exe_context, return_type, field_ast, info, path, data)
-        
+
     # print return_type, type(result)
     if isinstance(result, Exception):
         raise GraphQLLocatedError(field_asts, original_error=result, path=path)

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -539,6 +539,7 @@ def complete_value(
             ),
         )
 
+    # If result is ExecutionResult, update exe_context and complete for data field
     if isinstance(result, ExecutionResult):
         data = getattr(result, "data", None)
         extensions = getattr(result, "extensions", None)

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -136,7 +136,9 @@ def execute(
         if not exe_context.errors:
             return ExecutionResult(data=data)
 
-        return ExecutionResult(data=data, errors=exe_context.errors, extensions=exe_context.extensions)
+        return ExecutionResult(
+            data=data, errors=exe_context.errors, extensions=exe_context.extensions
+        )
 
     promise = (
         Promise.resolve(None).then(promise_executor).catch(on_rejected).then(on_resolve)
@@ -409,7 +411,7 @@ def subscribe_field(
         variable_values=exe_context.variable_values,
         context=context,
         path=path,
-        extensions=exe_context.extensions
+        extensions=exe_context.extensions,
     )
 
     executor = exe_context.executor
@@ -464,7 +466,7 @@ def complete_value_catching_error(
     info,  # type: ResolveInfo
     path,  # type: List[Union[int, str]]
     result,  # type: Any
-): 
+):
     # type: (...) -> Any
     # If the field type is non-nullable, then it is resolved without any
     # protection from errors.
@@ -534,15 +536,15 @@ def complete_value(
         )
 
     if isinstance(result, ExecutionResult):
-        data = getattr(result, 'data', None)
-        extensions = getattr(result, 'extensions', None)
-        errors = getattr(result, 'errors', None)
+        data = getattr(result, "data", None)
+        extensions = getattr(result, "extensions", None)
+        errors = getattr(result, "errors", None)
 
         if extensions:
             exe_context.update_extensions(extensions)
         if errors:
             for error in errors:
-                exe_context.report_error(error) 
+                exe_context.report_error(error)
 
         return complete_value(exe_context, return_type, field_ast, info, path, data)
 

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -133,10 +133,16 @@ def execute(
         if isinstance(data, Observable):
             return data
 
-        if not exe_context.errors:
-            return ExecutionResult(data=data)
+        errors = exe_context.errors or []
+        extensions = None
 
-        return ExecutionResult(data=data, errors=exe_context.errors)
+        if isinstance(data, ExecutionResult):
+            extensions = getattr(data, 'extensions', None)
+            data_errors = getattr(data, 'errors', None) or []
+            data = getattr(data, 'data', None)
+            errors = errors + data_errors
+
+        return ExecutionResult(data=data, errors=errors or None, extensions=extensions)
 
     promise = (
         Promise.resolve(None).then(promise_executor).catch(on_rejected).then(on_resolve)

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -546,7 +546,7 @@ def complete_value(
             for error in errors:
                 exe_context.report_error(error)
 
-        return complete_value(exe_context, return_type, field_ast, info, path, data)
+        return complete_value(exe_context, return_type, field_asts, info, path, data)
 
     # print return_type, type(result)
     if isinstance(result, Exception):

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -133,12 +133,15 @@ def execute(
         if isinstance(data, Observable):
             return data
 
-        if not exe_context.errors:
-            return ExecutionResult(data=data)
+        kwargs = {}
 
-        return ExecutionResult(
-            data=data, errors=exe_context.errors, extensions=exe_context.extensions
-        )
+        if exe_context.errors:
+            kwargs["errors"] = exe_context.errors
+
+        if exe_context.extensions:
+            kwargs["extensions"] = exe_context.extensions
+
+        return ExecutionResult(data=data, **kwargs)
 
     promise = (
         Promise.resolve(None).then(promise_executor).catch(on_rejected).then(on_resolve)

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -133,15 +133,16 @@ def execute(
         if isinstance(data, Observable):
             return data
 
-        kwargs = {}
-
-        if exe_context.errors:
-            kwargs["errors"] = exe_context.errors
-
-        if exe_context.extensions:
-            kwargs["extensions"] = exe_context.extensions
-
-        return ExecutionResult(data=data, **kwargs)
+        if exe_context.errors and exe_context.extensions:
+            return ExecutionResult(
+                data=data, errors=exe_context.errors, extensions=exe_context.extensions
+            )
+        elif exe_context.errors:
+            return ExecutionResult(data=data, errors=exe_context.errors)
+        elif exe_context.extensions:
+            return ExecutionResult(data=data, extensions=exe_context.extensions)
+        else:
+            return ExecutionResult(data=data)
 
     promise = (
         Promise.resolve(None).then(promise_executor).catch(on_rejected).then(on_resolve)

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from copy import deepcopy
 import logging
 from traceback import format_exception
 
@@ -155,7 +156,7 @@ class ExecutionContext(object):
         self.errors.append(error)
 
     def update_extensions(self, extensions):
-        self.extensions = extensions.copy() if self.extensions else {}
+        self.extensions = deepcopy(extensions) if self.extensions else {}
         self.extensions.update(extensions)
 
     def get_sub_fields(self, return_type, field_asts):

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -156,6 +156,7 @@ class ExecutionContext(object):
         self.errors.append(error)
 
     def update_extensions(self, extensions):
+        # type: Dict
         self.extensions = deepcopy(extensions) if self.extensions else {}
         self.extensions.update(extensions)
 

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -156,7 +156,7 @@ class ExecutionContext(object):
         self.errors.append(error)
 
     def update_extensions(self, extensions):
-        # type: Dict
+        # type: (Dict[str, Any]) -> None
         self.extensions = deepcopy(extensions) if self.extensions else {}
         self.extensions.update(extensions)
 

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -54,6 +54,7 @@ class ExecutionContext(object):
         "middleware",
         "allow_subscriptions",
         "_subfields_cache",
+        "extensions",
     )
 
     def __init__(
@@ -67,6 +68,7 @@ class ExecutionContext(object):
         executor,  # type: Any
         middleware,  # type: Optional[Any]
         allow_subscriptions,  # type: bool
+        extensions=None,  # type: Dict
     ):
         # type: (...) -> None
         """Constructs a ExecutionContext object from the arguments passed
@@ -126,6 +128,7 @@ class ExecutionContext(object):
         self.middleware = middleware
         self.allow_subscriptions = allow_subscriptions
         self._subfields_cache = {}  # type: Dict[Tuple[GraphQLObjectType, Tuple[Field, ...]], DefaultOrderedDict]
+        self.extensions = extensions
 
     def get_field_resolver(self, field_resolver):
         # type: (Callable) -> Callable
@@ -150,6 +153,10 @@ class ExecutionContext(object):
         )
         logger.error("".join(exception))
         self.errors.append(error)
+
+    def update_extensions(self, extensions):
+        self.extensions = extensions.copy() if self.extensions else {}
+        self.extensions.update(extensions)
 
     def get_sub_fields(self, return_type, field_asts):
         # type: (GraphQLObjectType, List[Field]) -> DefaultOrderedDict

--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -157,8 +157,9 @@ class ExecutionContext(object):
 
     def update_extensions(self, extensions):
         # type: (Dict[str, Any]) -> None
-        self.extensions = deepcopy(extensions) if self.extensions else {}
-        self.extensions.update(extensions)
+        if extensions:
+            self.extensions = self.extensions or {}
+            self.extensions.update(extensions)
 
     def get_sub_fields(self, return_type, field_asts):
         # type: (GraphQLObjectType, List[Field]) -> DefaultOrderedDict


### PR DESCRIPTION
The main intention of this PR is to expose `extensions` to middleware and resolvers. The execution is responsible for creating the `ExecutionResult` and does not currently provide a means to inject `extensions` data. This PR gives all resolvers the option to return the `ExecutionResult` instance instead of the raw data object. In order to prevent field level resolvers overriding the extensions data I added it to the `ExecutionContext` so it can be maintained and updated across all the resolvers. 

Fixes #206