### PR TITLE
Fix Python 3.7 deprecation warnings

### DIFF
--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -1,4 +1,9 @@
 import collections
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
 import functools
 import logging
 import sys
@@ -580,7 +585,7 @@ def complete_list_value(
     """
     Complete a list value by completing each item in the list with the inner type
     """
-    assert isinstance(result, collections.Iterable), (
+    assert isinstance(result, collections_abc.Iterable), (
         "User Error: expected iterable, but did not find one " + "for field {}.{}."
     ).format(info.parent_type, info.field_name)
 

--- a/graphql/execution/values.py
+++ b/graphql/execution/values.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
 import json
 
 from six import string_types
@@ -160,7 +163,7 @@ def coerce_value(type, value):
     if isinstance(type, GraphQLList):
         item_type = type.of_type
         if not isinstance(value, string_types) and isinstance(
-            value, collections.Iterable
+            value, collections_abc.Iterable
         ):
             return [coerce_value(item_type, item) for item in value]
         else:

--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -1,4 +1,9 @@
 import collections
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
 import copy
 
 from ..language import ast
@@ -234,7 +239,7 @@ def define_field_map(
     if callable(field_map):
         field_map = field_map()
 
-    assert isinstance(field_map, collections.Mapping) and len(field_map) > 0, (
+    assert isinstance(field_map, collections_abc.Mapping) and len(field_map) > 0, (
         "{} fields must be a mapping (dict / OrderedDict) with field names as keys or a "
         "function which returns such a mapping."
     ).format(type)
@@ -248,7 +253,7 @@ def define_field_map(
 
         if field_args:
             assert isinstance(
-                field_args, collections.Mapping
+                field_args, collections_abc.Mapping
             ), "{}.{} args must be a mapping (dict / OrderedDict) with argument names as keys.".format(
                 type, field_name
             )
@@ -520,7 +525,7 @@ class GraphQLEnumType(GraphQLNamedType):
         if isinstance(value, PyEnum):
             # We handle PyEnum values
             value = value.value
-        if isinstance(value, collections.Hashable):
+        if isinstance(value, collections_abc.Hashable):
             enum_value = self._value_lookup.get(value)
             if enum_value:
                 return enum_value.name
@@ -528,7 +533,7 @@ class GraphQLEnumType(GraphQLNamedType):
         return None
 
     def parse_value(self, value):
-        if isinstance(value, collections.Hashable):
+        if isinstance(value, collections_abc.Hashable):
             enum_value = self._name_lookup.get(value)
 
             if enum_value:
@@ -555,7 +560,7 @@ class GraphQLEnumType(GraphQLNamedType):
 
 def define_enum_values(type, value_map):
     assert (
-        isinstance(value_map, collections.Mapping) and len(value_map) > 0
+        isinstance(value_map, collections_abc.Mapping) and len(value_map) > 0
     ), "{} values must be a mapping (dict / OrderedDict) with value names as keys.".format(
         type
     )
@@ -661,7 +666,7 @@ class GraphQLInputObjectType(GraphQLNamedType):
         else:
             fields = self._fields
 
-        assert isinstance(fields, collections.Mapping) and len(fields) > 0, (
+        assert isinstance(fields, collections_abc.Mapping) and len(fields) > 0, (
             "{} fields must be a mapping (dict / OrderedDict) with field names as keys or a "
             "function which returns such a mapping."
         ).format(self)

--- a/graphql/type/directives.py
+++ b/graphql/type/directives.py
@@ -1,4 +1,7 @@
-import collections
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
 
 from ..pyutils.ordereddict import OrderedDict
 from ..utils.assert_valid_name import assert_valid_name
@@ -43,7 +46,7 @@ class GraphQLDirective(object):
         assert name, "Directive must be named."
         assert_valid_name(name)
         assert isinstance(
-            locations, collections.Iterable
+            locations, collections_abc.Iterable
         ), "Must provide locations for directive."
 
         self.name = name
@@ -52,7 +55,7 @@ class GraphQLDirective(object):
 
         if args:
             assert isinstance(
-                args, collections.Mapping
+                args, collections_abc.Mapping
             ), "{} args must be a dict with argument names as keys.".format(name)
             for arg_name, _arg in args.items():
                 assert_valid_name(arg_name)

--- a/graphql/type/schema.py
+++ b/graphql/type/schema.py
@@ -1,4 +1,7 @@
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 from .definition import GraphQLObjectType
 from .directives import GraphQLDirective, specified_directives

--- a/graphql/type/typemap.py
+++ b/graphql/type/typemap.py
@@ -1,4 +1,9 @@
-from collections import OrderedDict, Sequence, defaultdict
+from collections import OrderedDict, defaultdict
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 from functools import reduce
 
 from ..utils.type_comparators import is_equal_type, is_type_sub_type_of

--- a/graphql/utils/is_valid_value.py
+++ b/graphql/utils/is_valid_value.py
@@ -2,7 +2,10 @@
     Implementation of isValidJSValue from graphql.s
 """
 
-import collections
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    import collections as collections_abc  # type: ignore
 import json
 
 from six import string_types
@@ -38,7 +41,7 @@ def is_valid_value(value, type):
     if isinstance(type, GraphQLList):
         item_type = type.of_type
         if not isinstance(value, string_types) and isinstance(
-            value, collections.Iterable
+            value, collections_abc.Iterable
         ):
             errors = []
             for i, item in enumerate(value):
@@ -52,7 +55,7 @@ def is_valid_value(value, type):
             return is_valid_value(value, item_type)
 
     if isinstance(type, GraphQLInputObjectType):
-        if not isinstance(value, collections.Mapping):
+        if not isinstance(value, collections_abc.Mapping):
             return [u'Expected "{}", found not an object.'.format(type)]
 
         fields = type.fields


### PR DESCRIPTION
Importing ABCs directly from the `collections` module is deprecated
in Python 3.7.