### PR TITLE
fix UnicodeDecodeError in format_error

### DIFF
--- a/graphql/error/format_error.py
+++ b/graphql/error/format_error.py
@@ -1,5 +1,3 @@
-from six import text_type
-
 from .base import GraphQLError
 
 # Necessary for static type checking
@@ -9,7 +7,12 @@ if False:  # flake8: noqa
 
 def format_error(error):
     # type: (Exception) -> Dict[str, Any]
-    formatted_error = {"message": text_type(error)}  # type: Dict[str, Any]
+    # Protect against UnicodeEncodeError when run in py2 (#216)
+    try:
+        message = str(error)
+    except UnicodeEncodeError:
+        message = error.message.encode("utf-8")  # type: ignore
+    formatted_error = {"message": message}  # type: Dict[str, Any]
     if isinstance(error, GraphQLError):
         if error.locations is not None:
             formatted_error["locations"] = [

--- a/graphql/execution/tests/test_format_error.py
+++ b/graphql/execution/tests/test_format_error.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+import pytest
+
+from graphql.error import GraphQLError, format_error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        GraphQLError("UNIÇODÉ!"),
+        GraphQLError("\xd0\xbe\xd1\x88\xd0\xb8\xd0\xb1\xd0\xba\xd0\xb0"),
+    ],
+)
+def test_unicode_format_error(error):
+    # type: (GraphQLError) -> None
+    assert isinstance(format_error(error), dict)


### PR DESCRIPTION
Fix for #216 
With logic like [here](https://github.com/graphql-python/graphql-core/blob/9202021fc87db9c175e115016cd53e5d9d085ac6/graphql/error/located_error.py#L22) in `GraphQLLocatedError`