### PR TITLE
Add HandledGraphQLError that does not log an exception

### DIFF
--- a/graphql/error/__init__.py
+++ b/graphql/error/__init__.py
@@ -1,6 +1,13 @@
-from .base import GraphQLError
+from .base import GraphQLError, HandledGraphQLError
 from .located_error import GraphQLLocatedError
 from .syntax_error import GraphQLSyntaxError
 from .format_error import format_error
 
-__all__ = ["GraphQLError", "GraphQLLocatedError", "GraphQLSyntaxError", "format_error"]
+
+__all__ = [
+    "GraphQLError",
+    "GraphQLLocatedError",
+    "GraphQLSyntaxError",
+    "HandledGraphQLError",
+    "format_error",
+]

--- a/graphql/error/base.py
+++ b/graphql/error/base.py
@@ -78,3 +78,6 @@ class GraphQLError(Exception):
             if self.positions and source:
                 self._locations = [get_location(source, pos) for pos in self.positions]
         return self._locations
+
+class HandledGraphQLError(GraphQLError):
+    pass

--- a/graphql/execution/executor.py
+++ b/graphql/execution/executor.py
@@ -8,7 +8,7 @@ from rx import Observable
 from six import string_types
 from promise import Promise, promise_for_dict, is_thenable
 
-from ..error import GraphQLError, GraphQLLocatedError
+from ..error import GraphQLError, GraphQLLocatedError, HandledGraphQLError
 from ..pyutils.default_ordered_dict import DefaultOrderedDict
 from ..pyutils.ordereddict import OrderedDict
 from ..utils.undefined import Undefined
@@ -445,6 +445,8 @@ def resolve_or_error(
     # type: (...) -> Any
     try:
         return executor.execute(resolve_fn, source, info, **args)
+    except HandledGraphQLError:
+        raise
     except Exception as e:
         logger.exception(
             "An error occurred while resolving field {}.{}".format(


### PR DESCRIPTION
I'm trying to send a custom error message in a web response. I can raise an exception to do that but I'm also getting sentry reports that I don't want.

In a Django project Sentry is setup to handle logging. When graphql-core logs this exception I get a sentry report. 

https://github.com/graphql-python/graphql-core/blob/9202021fc87db9c175e115016cd53e5d9d085ac6/graphql/execution/executor.py#L446-L455

I want to be able to prevent the sentry report. 

To send a custom error message back to the user you would just `raise HandledGraphQLError(msg)`.

Here is the Django logging config for reference. Let me know if there is a better solution.
```
    LOGGING = {
        'version': 1,
        'disable_existing_loggers': True,
        'root': {
            'level': 'WARNING',
            'handlers': ['sentry'],
        },
        'formatters': {
            'verbose': {
                'format': '%(levelname)s %(asctime)s %(module)s '
                          '%(process)d %(thread)d %(message)s'
            },
        },
        'handlers': {
            'sentry': {
                # To capture more than ERROR, change to WARNING, INFO, etc.
                'level': 'ERROR',
                'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
                'tags': {
                    'build_number': os.environ.get('BUILD_NUMBER', 'none'),
                    'env': RUNNING_ENV
                }
            },
            'console': {
                'level': 'DEBUG',
                'class': 'logging.StreamHandler',
                'formatter': 'verbose'
            }
        },
        'loggers': {
            'raven': {
                'level': 'DEBUG',
                'handlers': ['console'],
                'propagate': False,
            },
            'sentry.errors': {
                'level': 'DEBUG',
                'handlers': ['console'],
                'propagate': False,
            }
        },
    }
```