### PR TITLE
Update pytest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,11 @@ sys.path[:] = path_copy
 install_requires = ["six>=1.10.0", "promise>=2.1", "rx>=1.6.0"]
 
 tests_requires = [
-    "pytest==3.0.2",
+    "pytest>=3.3,<4.0",
     "pytest-django==2.9.1",
     "pytest-cov==2.3.1",
     "coveralls",
-    "gevent>=1.1rc1",
+    "gevent>=1.1",
     "six>=1.10.0",
     "pytest-benchmark==3.0.0",
     "pytest-mock==1.2",
@@ -81,5 +81,5 @@ setup(
     install_requires=install_requires,
     tests_require=tests_requires,
     cmdclass={"test": PyTest},
-    extras_require={"gevent": ["gevent>=1.1rc1"], "test": tests_requires},
+    extras_require={"gevent": ["gevent>=1.1"], "test": tests_requires},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py27,py34,py35,py36,py37,pre-commit,pypy,mypy,docs
 
 [testenv]
 deps =
-    pytest>=2.7.2
-    gevent>=1.1rc1
+    pytest>=3.3,<4.0
+    gevent>=1.1
     promise>=2.0
     six>=1.10.0
     pytest-mock


### PR DESCRIPTION
Restrict the pytest version, because

* the middleware test needs pytest >= 3.3
* other tests don't run with pytest >= 4.0