### PR TITLE
Add traceback to errors from failed promises

### DIFF
--- a/graphql/error/located_error.py
+++ b/graphql/error/located_error.py
@@ -26,9 +26,15 @@ class GraphQLLocatedError(GraphQLError):
         else:
             message = "An unknown error occurred."
 
-        stack = original_error and getattr(original_error, "stack", None)
-        if not stack:
-            stack = sys.exc_info()[2]
+        stack = (
+            original_error
+            and (
+                getattr(original_error, "stack", None)
+                # unfortunately, this is only available in Python 3:
+                or getattr(original_error, "__traceback__", None)
+            )
+            or sys.exc_info()[2]
+        )
 
         super(GraphQLLocatedError, self).__init__(
             message=message, nodes=nodes, stack=stack, path=path


### PR DESCRIPTION
The stack attribute of GraphQLLocatedErrors was not set for errors that resulted from asynchronous resolvers.

This PR adds a unit test for this problem and a solution that works with Python >= 3 and solves #237.

For Python 2 this problem is not yet solved, and may be never solved, because dealing with stack traces is much more difficult there.