### PR TITLE
setup.py: Uncommented long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     version=version,
     description="GraphQL implementation for Python",
     long_description=open("README.md").read(),
-    # long_description_content_type="text/markdown",
+    long_description_content_type="text/markdown",
     url="https://github.com/graphql-python/graphql-core",
     download_url="https://github.com/graphql-python/graphql-core/releases",
     author="Syrus Akbary, Jake Heinz, Taeho Kim",


### PR DESCRIPTION
Then Pypi also knows that the README is a markdown file so it can get rendered properly.
What confuses me is that the line has never been commented but has just been added in the commented version in a7ce75e339a6aaf3a0bb52175c41776edd549bdc