### PR TITLE
If using Python >=3.7, use built-in dict as OrderedDict

### DIFF
--- a/graphql/pyutils/ordereddict.py
+++ b/graphql/pyutils/ordereddict.py
@@ -1,10 +1,8 @@
 import sys
 
-if (sys.version_info.major, sys.version_info.minor) >= (3, 7):
+if sys.version_info >= (3, 7):
     # As of Python 3.7, dictionaries are specified to preserve insertion order
-    class OrderedDict(dict):
-        pass
-
+    OrderedDict = dict
 
 else:
     try:
@@ -13,5 +11,6 @@ else:
         from cyordereddict import OrderedDict  # type: ignore
     except ImportError:
         from collections import OrderedDict
+
 
 __all__ = ["OrderedDict"]

--- a/graphql/pyutils/ordereddict.py
+++ b/graphql/pyutils/ordereddict.py
@@ -1,8 +1,17 @@
-try:
-    # Try to load the Cython performant OrderedDict (C)
-    # as is more performant than collections.OrderedDict (Python)
-    from cyordereddict import OrderedDict  # type: ignore
-except ImportError:
-    from collections import OrderedDict
+import sys
+
+if (sys.version_info.major, sys.version_info.minor) >= (3, 7):
+    # As of Python 3.7, dictionaries are specified to preserve insertion order
+    class OrderedDict(dict):
+        pass
+
+
+else:
+    try:
+        # Try to load the Cython performant OrderedDict (C)
+        # as is more performant than collections.OrderedDict (Python)
+        from cyordereddict import OrderedDict  # type: ignore
+    except ImportError:
+        from collections import OrderedDict
 
 __all__ = ["OrderedDict"]

--- a/graphql/type/definition.py
+++ b/graphql/type/definition.py
@@ -404,6 +404,7 @@ class GraphQLInterfaceType(GraphQLNamedType):
     @cached_property
     def fields(self):
         # type: () -> Dict[str, GraphQLField]
+        assert self._fields is not None, '"fields" cannot be None'
         return define_field_map(self, self._fields)
 
 

--- a/graphql/type/tests/test_enum_type.py
+++ b/graphql/type/tests/test_enum_type.py
@@ -1,3 +1,4 @@
+import sys
 from collections import OrderedDict
 from rx import Observable
 from graphql import graphql
@@ -11,6 +12,7 @@ from graphql.type import (
     GraphQLSchema,
     GraphQLString,
 )
+import pytest
 
 ColorType = GraphQLEnumType(
     name="Color",
@@ -263,6 +265,10 @@ def test_presents_a_get_value_api():
     assert badUsage is None
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 7),
+    reason="As of Python 3.7 we use built-in dicts, which preserve order",
+)
 def test_sorts_values_if_not_using_ordered_dict():
     enum = GraphQLEnumType(
         name="Test",


### PR DESCRIPTION
Since dictionaries are specified to preserve insertion order in Python 3.7 and up (see https://docs.python.org/3/whatsnew/3.7.html), it seems simplest and most performant to use the built-in type where possible.

This change _does_ specify a distinct type, to continue to make clear that in certain situations order-preservation is _relied on_ rather than being a convenient accident.