### PR TITLE
Support new multiple inheritance syntax

### DIFF
--- a/graphql/language/lexer.py
+++ b/graphql/language/lexer.py
@@ -210,6 +210,8 @@ ignored_whitespace_characters = frozenset(
         0x000D,  # carriage return
         # Comma
         0x002C,
+        # Ampersand
+        0x0026,
     ]
 )
 

--- a/graphql/language/printer.py
+++ b/graphql/language/printer.py
@@ -169,7 +169,7 @@ class PrintingVisitor(Visitor):
             [
                 "type",
                 node.name,
-                wrap("implements ", join(node.interfaces, ", ")),
+                wrap("implements ", join(node.interfaces, " & ")),
                 join(node.directives, " "),
                 block(node.fields),
             ],

--- a/graphql/language/tests/test_schema_parser.py
+++ b/graphql/language/tests/test_schema_parser.py
@@ -153,7 +153,7 @@ def test_parses_simple_type_inheriting_interface():
 
 def test_parses_simple_type_inheriting_multiple_interfaces():
     # type: () -> None
-    body = "type Hello implements Wo, rld { }"
+    body = "type Hello implements Wo & rld { }"
     loc = create_loc_fn(body)
     doc = parse(body)
     expected = ast.Document(

--- a/graphql/utils/schema_printer.py
+++ b/graphql/utils/schema_printer.py
@@ -128,7 +128,7 @@ def _print_object(type):
     # type: (GraphQLObjectType) -> str
     interfaces = type.interfaces
     implemented_interfaces = (
-        " implements {}".format(", ".join(i.name for i in interfaces))
+        " implements {}".format(" & ".join(i.name for i in interfaces))
         if interfaces
         else ""
     )

--- a/graphql/utils/tests/test_extend_schema.py
+++ b/graphql/utils/tests/test_extend_schema.py
@@ -568,7 +568,7 @@ type Biz {
   fizz: String
 }
 
-type Foo implements SomeInterface, NewInterface {
+type Foo implements SomeInterface & NewInterface {
   name: String
   some: SomeInterface
   tree: [Foo]!
@@ -637,7 +637,7 @@ type Bar implements SomeInterface {
   foo: Foo
 }
 
-type Biz implements NewInterface, SomeInterface {
+type Biz implements NewInterface & SomeInterface {
   fizz: String
   buzz: String
   name: String

--- a/graphql/utils/tests/test_schema_printer.py
+++ b/graphql/utils/tests/test_schema_printer.py
@@ -390,7 +390,7 @@ interface Baaz {
   int: Int
 }
 
-type Bar implements Foo, Baaz {
+type Bar implements Foo & Baaz {
   str: String
   int: Int
 }


### PR DESCRIPTION
graphql-js 0.13 introduced a new multiple inheritance syntax and some packages won't be able to parse the schemas generated by `graphql-core` v2.

I've changed the multiple inheritance character but should there be an option to toggle between the two since this is a breaking change?