### PR TITLE
Add py.typed file to allow users to use the types this library provides

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,4 +82,5 @@ setup(
     tests_require=tests_requires,
     cmdclass={"test": PyTest},
     extras_require={"gevent": ["gevent>=1.1"], "test": tests_requires},
+    package_data={"graphql": ["py.typed"]},
 )


### PR DESCRIPTION
I was generating type stubs for this library and noticed it already has some decent typing! This PR adds a py.typed file to the library, allowing consumers to use the types for type checking their own projects.