### PR TITLE
Make default_backend type annotation more generous

### DIFF
--- a/graphql/backend/__init__.py
+++ b/graphql/backend/__init__.py
@@ -4,17 +4,19 @@ This module provides a dynamic way of using different
 engines for a GraphQL schema query resolution.
 """
 
+from typing import Optional
+
 from .base import GraphQLBackend, GraphQLDocument
 from .core import GraphQLCoreBackend
 from .decider import GraphQLDeciderBackend
 from .cache import GraphQLCachedBackend
 
 
-_default_backend = None
+_default_backend = None  # type: Optional[GraphQLBackend]
 
 
 def get_default_backend():
-    # type: () -> GraphQLCoreBackend
+    # type: () -> GraphQLBackend
     global _default_backend
     if _default_backend is None:
         _default_backend = GraphQLCoreBackend()

--- a/graphql/backend/__init__.py
+++ b/graphql/backend/__init__.py
@@ -22,7 +22,7 @@ def get_default_backend():
 
 
 def set_default_backend(backend):
-    # type: (GraphQLCoreBackend) -> None
+    # type: (GraphQLBackend) -> None
     global _default_backend
     assert isinstance(
         backend, GraphQLBackend


### PR DESCRIPTION
The code itself documents that only a `GraphQLBackend` is needed here, so relax the type annotation to match. Currently the annotation prevents callers setting any of the other types of backend as the default.