### PR TITLE
Add support for custom validators

### DIFF
--- a/graphql/backend/tests/test_core.py
+++ b/graphql/backend/tests/test_core.py
@@ -3,14 +3,19 @@
 """Tests for `graphql.backend.core` module."""
 
 import pytest
+
+from graphql import GraphQLError
 from graphql.execution.executors.sync import SyncExecutor
+from graphql.validation.rules.base import ValidationRule
 
 from ..base import GraphQLBackend, GraphQLDocument
 from ..core import GraphQLCoreBackend
 from .schema import schema
 
 if False:
-    from typing import Any
+    from pytest_mock import MockFixture
+    from typing import Any, List, Optional, Type
+    from graphql.language.ast import Document
 
 
 def test_core_backend():
@@ -52,3 +57,42 @@ def test_backend_can_execute_custom_executor():
     assert not result.errors
     assert result.data == {"hello": "World"}
     assert executor.executed
+
+
+class AlwaysFailValidator(ValidationRule):
+    # noinspection PyPep8Naming
+    def enter_Document(self, node, key, parent, path, ancestors):
+        # type: (Document, Optional[Any], Optional[Any], List, List) -> None
+        self.context.report_error(GraphQLError("Test validator failure", [node]))
+
+
+class CustomValidatorBackend(GraphQLCoreBackend):
+    def get_validation_rules(self):
+        # type: () -> List[Type[ValidationRule]]
+        return [AlwaysFailValidator]
+
+
+def test_backend_custom_validators_result():
+    # type: () -> None
+    backend = CustomValidatorBackend()
+    assert isinstance(backend, CustomValidatorBackend)
+    document = backend.document_from_string(schema, "{ hello }")
+    assert isinstance(document, GraphQLDocument)
+    result = document.execute()
+    assert result.errors
+    assert len(result.errors) == 1
+    assert result.errors[0].message == "Test validator failure"
+
+
+def test_backend_custom_validators_in_validation_args(mocker):
+    # type: (MockFixture) -> None
+    mocked_validate = mocker.patch("graphql.backend.core.validate")
+    backend = CustomValidatorBackend()
+    assert isinstance(backend, CustomValidatorBackend)
+    document = backend.document_from_string(schema, "{ hello }")
+    assert isinstance(document, GraphQLDocument)
+    mocked_validate.assert_not_called()
+    result = document.execute()
+    mocked_validate.assert_called_once()
+    (args, kwargs) = mocked_validate.call_args
+    assert [AlwaysFailValidator] in args


### PR DESCRIPTION
Support extending the `GraphQLCoreBackend` class with custom validators by
adding a function `get_validation_rules` that can be overridden in
subclasses where needed.

This change in combination with setting the default graphql backend
allows for easy additions to validation rules. An example use case would
be if there's a need to perform query cost or depth analysis, one can
create a validator that restricts execution of the query based on it's
execution cost.

Of course this could also be used to remove validators if that is
necessary for some use case.

Resolves #267