### PR TITLE
Don't format exceptions before logging

### DIFF
--- a/graphql/execution/utils.py
+++ b/graphql/execution/utils.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-from traceback import format_exception
 
 from ..error import GraphQLError
 from ..language import ast
@@ -149,10 +148,10 @@ class ExecutionContext(object):
 
     def report_error(self, error, traceback=None):
         # type: (Exception, Optional[TracebackType]) -> None
-        exception = format_exception(
-            type(error), error, getattr(error, "stack", None) or traceback
+        logger.exception(
+            error,
+            exc_info=(type(error), error, getattr(error, "stack", None) or traceback),
         )
-        logger.error("".join(exception))
         self.errors.append(error)
 
     def get_sub_fields(self, return_type, field_asts):


### PR DESCRIPTION
Fixes #253 

`traceback.format_exception` is added to `report_error` with https://github.com/graphql-python/graphql-core/pull/154 two years ago, it solves another problem but i couldn't understand why did anyone need to stringify all exceptions on such central place. It removes all details of an exception and downgrades is to simple string. That change makes crucial impact on error logging.

Before the change:
![image](https://user-images.githubusercontent.com/166637/76163961-cbf57200-615b-11ea-9221-371969cdcf26.png)
![image](https://user-images.githubusercontent.com/166637/76164058-c51b2f00-615c-11ea-8bf2-ea0a7f7d52f6.png)

All exceptions have same type and same title. No traceback. There are some autogenerated breadcrumbs thanks to Sentry, but it's impossible to find why and where this error is happening. Message is truncated. All details are lost.

After the change:

![image](https://user-images.githubusercontent.com/166637/76164026-55a53f80-615c-11ea-9940-04656c5cf71e.png)
![image](https://user-images.githubusercontent.com/166637/76164043-8b4a2880-615c-11ea-9e0f-3867a0f55b8f.png)

Exceptions have their own types. Message is short, clear and gives information. Traceback is on place. Breadcrumbs are useful.